### PR TITLE
Add prefix to category header files and names

### DIFF
--- a/Mac/KSCrash-Mac.xcodeproj/project.pbxproj
+++ b/Mac/KSCrash-Mac.xcodeproj/project.pbxproj
@@ -174,8 +174,8 @@
 		CB62411117EBCA74006471F1 /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56DE17EB9B89000C56D3 /* KSVarArgs.h */; };
 		CB62411217EBCA74006471F1 /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56DF17EB9B89000C56D3 /* NSData+GZip.h */; };
 		CB62411317EBCA74006471F1 /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E017EB9B89000C56D3 /* NSData+GZip.m */; };
-		CB62411617EBCA74006471F1 /* NSError+SimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E317EB9B89000C56D3 /* NSError+SimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CB62411717EBCA74006471F1 /* NSError+SimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E417EB9B89000C56D3 /* NSError+SimpleConstructor.m */; };
+		CB62411617EBCA74006471F1 /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E317EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CB62411717EBCA74006471F1 /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E417EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m */; };
 		CB62411817EBCA74006471F1 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E517EB9B89000C56D3 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB62411917EBCA74006471F1 /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E617EB9B89000C56D3 /* NSMutableData+AppendUTF8.m */; };
 		CB62411A17EBCA74006471F1 /* KSCrashInstallation+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E570517EB9BA8000C56D3 /* KSCrashInstallation+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -232,7 +232,7 @@
 		CB7A6CE017FB9CEE00997792 /* KSSysCtl_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CBA17FB9CEE00997792 /* KSSysCtl_Tests.m */; };
 		CB7A6CE117FB9CEE00997792 /* KSSystemInfo_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CBB17FB9CEE00997792 /* KSSystemInfo_Tests.m */; };
 		CB7A6CE317FB9CEE00997792 /* NSData+Gzip_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CBD17FB9CEE00997792 /* NSData+Gzip_Tests.m */; };
-		CB7A6CE517FB9CEE00997792 /* NSError+SimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CBF17FB9CEE00997792 /* NSError+SimpleConstructor_Tests.m */; };
+		CB7A6CE517FB9CEE00997792 /* NSError+KSCrashSimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CBF17FB9CEE00997792 /* NSError+KSCrashSimpleConstructor_Tests.m */; };
 		CB7A6CE617FB9CEE00997792 /* NSMutableData+AppendUTF8_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CC017FB9CEE00997792 /* NSMutableData+AppendUTF8_Tests.m */; };
 		CB7A6CE817FB9CEE00997792 /* XCTestCase+KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CC317FB9CEE00997792 /* XCTestCase+KSCrash.m */; };
 		CB7A6CE917FB9D0900997792 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB8E571D17EBA8DF000C56D3 /* SystemConfiguration.framework */; };
@@ -326,8 +326,8 @@
 		CB8E56F417EB9B89000C56D3 /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56DE17EB9B89000C56D3 /* KSVarArgs.h */; };
 		CB8E56F517EB9B89000C56D3 /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56DF17EB9B89000C56D3 /* NSData+GZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB8E56F617EB9B89000C56D3 /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E017EB9B89000C56D3 /* NSData+GZip.m */; };
-		CB8E56F917EB9B89000C56D3 /* NSError+SimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E317EB9B89000C56D3 /* NSError+SimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CB8E56FA17EB9B89000C56D3 /* NSError+SimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E417EB9B89000C56D3 /* NSError+SimpleConstructor.m */; };
+		CB8E56F917EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E317EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CB8E56FA17EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E417EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m */; };
 		CB8E56FB17EB9B89000C56D3 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E517EB9B89000C56D3 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB8E56FC17EB9B89000C56D3 /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E617EB9B89000C56D3 /* NSMutableData+AppendUTF8.m */; };
 		CB8E570117EB9B95000C56D3 /* KSCrashDoctor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56FD17EB9B95000C56D3 /* KSCrashDoctor.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -493,7 +493,7 @@
 		CB7A6CBB17FB9CEE00997792 /* KSSystemInfo_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSSystemInfo_Tests.m; path = "../../Source/KSCrash-Tests/KSSystemInfo_Tests.m"; sourceTree = "<group>"; };
 		CB7A6CBC17FB9CEE00997792 /* KSZombie_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSZombie_Tests.m; path = "../../Source/KSCrash-Tests/KSZombie_Tests.m"; sourceTree = "<group>"; };
 		CB7A6CBD17FB9CEE00997792 /* NSData+Gzip_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+Gzip_Tests.m"; path = "../../Source/KSCrash-Tests/NSData+Gzip_Tests.m"; sourceTree = "<group>"; };
-		CB7A6CBF17FB9CEE00997792 /* NSError+SimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+SimpleConstructor_Tests.m"; path = "../../Source/KSCrash-Tests/NSError+SimpleConstructor_Tests.m"; sourceTree = "<group>"; };
+		CB7A6CBF17FB9CEE00997792 /* NSError+KSCrashSimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+KSCrashSimpleConstructor_Tests.m"; path = "../../Source/KSCrash-Tests/NSError+KSCrashSimpleConstructor_Tests.m"; sourceTree = "<group>"; };
 		CB7A6CC017FB9CEE00997792 /* NSMutableData+AppendUTF8_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+AppendUTF8_Tests.m"; path = "../../Source/KSCrash-Tests/NSMutableData+AppendUTF8_Tests.m"; sourceTree = "<group>"; };
 		CB7A6CC217FB9CEE00997792 /* XCTestCase+KSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+KSCrash.h"; path = "../../Source/KSCrash-Tests/XCTestCase+KSCrash.h"; sourceTree = "<group>"; };
 		CB7A6CC317FB9CEE00997792 /* XCTestCase+KSCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+KSCrash.m"; path = "../../Source/KSCrash-Tests/XCTestCase+KSCrash.m"; sourceTree = "<group>"; };
@@ -594,8 +594,8 @@
 		CB8E56DE17EB9B89000C56D3 /* KSVarArgs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSVarArgs.h; path = ../../Source/KSCrash/Reporting/Filters/Tools/KSVarArgs.h; sourceTree = "<group>"; };
 		CB8E56DF17EB9B89000C56D3 /* NSData+GZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+GZip.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.h"; sourceTree = "<group>"; };
 		CB8E56E017EB9B89000C56D3 /* NSData+GZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+GZip.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.m"; sourceTree = "<group>"; };
-		CB8E56E317EB9B89000C56D3 /* NSError+SimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+SimpleConstructor.h"; path = "../../Source/KSCrash/Recording/Tools/NSError+SimpleConstructor.h"; sourceTree = "<group>"; };
-		CB8E56E417EB9B89000C56D3 /* NSError+SimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+SimpleConstructor.m"; path = "../../Source/KSCrash/Recording/Tools/NSError+SimpleConstructor.m"; sourceTree = "<group>"; };
+		CB8E56E317EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+KSCrashSimpleConstructor.h"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.h"; sourceTree = "<group>"; };
+		CB8E56E417EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+KSCrashSimpleConstructor.m"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.m"; sourceTree = "<group>"; };
 		CB8E56E517EB9B89000C56D3 /* NSMutableData+AppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableData+AppendUTF8.h"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.h"; sourceTree = "<group>"; };
 		CB8E56E617EB9B89000C56D3 /* NSMutableData+AppendUTF8.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+AppendUTF8.m"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.m"; sourceTree = "<group>"; };
 		CB8E56FD17EB9B95000C56D3 /* KSCrashDoctor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashDoctor.h; path = ../../Source/KSCrash/Recording/KSCrashDoctor.h; sourceTree = "<group>"; };
@@ -870,7 +870,7 @@
 				CB7A6CBB17FB9CEE00997792 /* KSSystemInfo_Tests.m */,
 				CB7A6CBC17FB9CEE00997792 /* KSZombie_Tests.m */,
 				CB7A6CBD17FB9CEE00997792 /* NSData+Gzip_Tests.m */,
-				CB7A6CBF17FB9CEE00997792 /* NSError+SimpleConstructor_Tests.m */,
+				CB7A6CBF17FB9CEE00997792 /* NSError+KSCrashSimpleConstructor_Tests.m */,
 				CB7A6CC017FB9CEE00997792 /* NSMutableData+AppendUTF8_Tests.m */,
 				CB25A5D01DF22B2300EC2B02 /* TestThread.h */,
 				CB25A5D11DF22B2300EC2B02 /* TestThread.m */,
@@ -1034,8 +1034,8 @@
 				CB8E567817EB9B43000C56D3 /* KSSysCtl.h */,
 				CB25A5DF1DF236D500EC2B02 /* KSThread.c */,
 				CB25A5E01DF236D500EC2B02 /* KSThread.h */,
-				CB8E56E317EB9B89000C56D3 /* NSError+SimpleConstructor.h */,
-				CB8E56E417EB9B89000C56D3 /* NSError+SimpleConstructor.m */,
+				CB8E56E317EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h */,
+				CB8E56E417EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -1163,7 +1163,7 @@
 				CB6240E317EBCA74006471F1 /* KSSysCtl.h in Headers */,
 				CB2686191C694E4400EE4EB3 /* AlignOf.h in Headers */,
 				CB6240BB17EBCA74006471F1 /* KSCrashMonitor_Deadlock.h in Headers */,
-				CB62411617EBCA74006471F1 /* NSError+SimpleConstructor.h in Headers */,
+				CB62411617EBCA74006471F1 /* NSError+KSCrashSimpleConstructor.h in Headers */,
 				CB9821B11DFA070300164220 /* KSMachineContext_Apple.h in Headers */,
 				CB62411817EBCA74006471F1 /* NSMutableData+AppendUTF8.h in Headers */,
 				CB6240B917EBCA74006471F1 /* KSCrashMonitor_CPPException.h in Headers */,
@@ -1271,7 +1271,7 @@
 				CBBD3AA81CAD989400DBB897 /* KSCrashReportFilterStringify.h in Headers */,
 				CB8E568517EB9B43000C56D3 /* KSJSONCodec.h in Headers */,
 				CB8E565017EB9B35000C56D3 /* KSCrashMonitor_Deadlock.h in Headers */,
-				CB8E56F917EB9B89000C56D3 /* NSError+SimpleConstructor.h in Headers */,
+				CB8E56F917EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h in Headers */,
 				CB69B8D31DC04432002713B1 /* KSDate.h in Headers */,
 				CB2686131C694E4400EE4EB3 /* StringRef.h in Headers */,
 				CB2686291C694E4400EE4EB3 /* Malloc.h in Headers */,
@@ -1456,7 +1456,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CB62410F17EBCA74006471F1 /* KSReachabilityKSCrash.m in Sources */,
-				CB62411717EBCA74006471F1 /* NSError+SimpleConstructor.m in Sources */,
+				CB62411717EBCA74006471F1 /* NSError+KSCrashSimpleConstructor.m in Sources */,
 				CB6240F117EBCA74006471F1 /* KSCrashReportFilterGZip.m in Sources */,
 				CB6240D017EBCA74006471F1 /* KSJSONCodecObjC.m in Sources */,
 				CB69B8D21DC04432002713B1 /* KSDate.c in Sources */,
@@ -1576,7 +1576,7 @@
 				CB8E565117EB9B35000C56D3 /* KSCrashMonitor_Deadlock.m in Sources */,
 				CB8E562D17EB9AFD000C56D3 /* KSCrashC.c in Sources */,
 				CB8E563617EB9AFD000C56D3 /* KSCrashMonitorType.c in Sources */,
-				CB8E56FA17EB9B89000C56D3 /* NSError+SimpleConstructor.m in Sources */,
+				CB8E56FA17EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m in Sources */,
 				CB8F1DD41CCAF3B40022CDF0 /* KSCrashInstallation+Alert.m in Sources */,
 				CB69B8DE1DC0F106002713B1 /* KSLogger.c in Sources */,
 				CB8E56E817EB9B89000C56D3 /* Container+DeepSearch.m in Sources */,
@@ -1641,7 +1641,7 @@
 				CB7A6CC517FB9CEE00997792 /* FileBasedTestCase.m in Sources */,
 				CB7A6CC817FB9CEE00997792 /* KSCrashInstallationStandard_Tests.m in Sources */,
 				CB7A6CC617FB9CEE00997792 /* KSCrashInstallationEmail_Tests.m in Sources */,
-				CB7A6CE517FB9CEE00997792 /* NSError+SimpleConstructor_Tests.m in Sources */,
+				CB7A6CE517FB9CEE00997792 /* NSError+KSCrashSimpleConstructor_Tests.m in Sources */,
 				CB7A6CE317FB9CEE00997792 /* NSData+Gzip_Tests.m in Sources */,
 				CB25A5D21DF22B2300EC2B02 /* TestThread.m in Sources */,
 				CB7A6CCD17FB9CEE00997792 /* KSCrashReportFilterGZip_Tests.m in Sources */,

--- a/Mac/KSCrash-Mac.xcodeproj/project.pbxproj
+++ b/Mac/KSCrash-Mac.xcodeproj/project.pbxproj
@@ -176,8 +176,8 @@
 		CB62411317EBCA74006471F1 /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E017EB9B89000C56D3 /* NSData+KSCrashGZip.m */; };
 		CB62411617EBCA74006471F1 /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E317EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB62411717EBCA74006471F1 /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E417EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m */; };
-		CB62411817EBCA74006471F1 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E517EB9B89000C56D3 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CB62411917EBCA74006471F1 /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E617EB9B89000C56D3 /* NSMutableData+AppendUTF8.m */; };
+		CB62411817EBCA74006471F1 /* NSMutableData+KSCrashAppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E517EB9B89000C56D3 /* NSMutableData+KSCrashAppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CB62411917EBCA74006471F1 /* NSMutableData+KSCrashAppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E617EB9B89000C56D3 /* NSMutableData+KSCrashAppendUTF8.m */; };
 		CB62411A17EBCA74006471F1 /* KSCrashInstallation+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E570517EB9BA8000C56D3 /* KSCrashInstallation+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB62411B17EBCA74006471F1 /* KSCrashInstallation.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E570617EB9BA8000C56D3 /* KSCrashInstallation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB62411C17EBCA74006471F1 /* KSCrashInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E570717EB9BA8000C56D3 /* KSCrashInstallation.m */; };
@@ -233,7 +233,7 @@
 		CB7A6CE117FB9CEE00997792 /* KSSystemInfo_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CBB17FB9CEE00997792 /* KSSystemInfo_Tests.m */; };
 		CB7A6CE317FB9CEE00997792 /* NSData+Gzip_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CBD17FB9CEE00997792 /* NSData+Gzip_Tests.m */; };
 		CB7A6CE517FB9CEE00997792 /* NSError+KSCrashSimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CBF17FB9CEE00997792 /* NSError+KSCrashSimpleConstructor_Tests.m */; };
-		CB7A6CE617FB9CEE00997792 /* NSMutableData+AppendUTF8_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CC017FB9CEE00997792 /* NSMutableData+AppendUTF8_Tests.m */; };
+		CB7A6CE617FB9CEE00997792 /* NSMutableData+KSCrashAppendUTF8_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CC017FB9CEE00997792 /* NSMutableData+KSCrashAppendUTF8_Tests.m */; };
 		CB7A6CE817FB9CEE00997792 /* XCTestCase+KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CC317FB9CEE00997792 /* XCTestCase+KSCrash.m */; };
 		CB7A6CE917FB9D0900997792 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB8E571D17EBA8DF000C56D3 /* SystemConfiguration.framework */; };
 		CB7A6CEC17FB9D1300997792 /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CB7A6CEB17FB9D1300997792 /* libc++.dylib */; };
@@ -328,8 +328,8 @@
 		CB8E56F617EB9B89000C56D3 /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E017EB9B89000C56D3 /* NSData+KSCrashGZip.m */; };
 		CB8E56F917EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E317EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB8E56FA17EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E417EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m */; };
-		CB8E56FB17EB9B89000C56D3 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E517EB9B89000C56D3 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CB8E56FC17EB9B89000C56D3 /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E617EB9B89000C56D3 /* NSMutableData+AppendUTF8.m */; };
+		CB8E56FB17EB9B89000C56D3 /* NSMutableData+KSCrashAppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E517EB9B89000C56D3 /* NSMutableData+KSCrashAppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CB8E56FC17EB9B89000C56D3 /* NSMutableData+KSCrashAppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E617EB9B89000C56D3 /* NSMutableData+KSCrashAppendUTF8.m */; };
 		CB8E570117EB9B95000C56D3 /* KSCrashDoctor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56FD17EB9B95000C56D3 /* KSCrashDoctor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB8E570217EB9B95000C56D3 /* KSCrashDoctor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56FE17EB9B95000C56D3 /* KSCrashDoctor.m */; };
 		CB8E570317EB9B95000C56D3 /* KSCrashReportStore.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56FF17EB9B95000C56D3 /* KSCrashReportStore.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -494,7 +494,7 @@
 		CB7A6CBC17FB9CEE00997792 /* KSZombie_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSZombie_Tests.m; path = "../../Source/KSCrash-Tests/KSZombie_Tests.m"; sourceTree = "<group>"; };
 		CB7A6CBD17FB9CEE00997792 /* NSData+Gzip_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+Gzip_Tests.m"; path = "../../Source/KSCrash-Tests/NSData+Gzip_Tests.m"; sourceTree = "<group>"; };
 		CB7A6CBF17FB9CEE00997792 /* NSError+KSCrashSimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+KSCrashSimpleConstructor_Tests.m"; path = "../../Source/KSCrash-Tests/NSError+KSCrashSimpleConstructor_Tests.m"; sourceTree = "<group>"; };
-		CB7A6CC017FB9CEE00997792 /* NSMutableData+AppendUTF8_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+AppendUTF8_Tests.m"; path = "../../Source/KSCrash-Tests/NSMutableData+AppendUTF8_Tests.m"; sourceTree = "<group>"; };
+		CB7A6CC017FB9CEE00997792 /* NSMutableData+KSCrashAppendUTF8_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+KSCrashAppendUTF8_Tests.m"; path = "../../Source/KSCrash-Tests/NSMutableData+KSCrashAppendUTF8_Tests.m"; sourceTree = "<group>"; };
 		CB7A6CC217FB9CEE00997792 /* XCTestCase+KSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+KSCrash.h"; path = "../../Source/KSCrash-Tests/XCTestCase+KSCrash.h"; sourceTree = "<group>"; };
 		CB7A6CC317FB9CEE00997792 /* XCTestCase+KSCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+KSCrash.m"; path = "../../Source/KSCrash-Tests/XCTestCase+KSCrash.m"; sourceTree = "<group>"; };
 		CB7A6CEB17FB9D1300997792 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
@@ -596,8 +596,8 @@
 		CB8E56E017EB9B89000C56D3 /* NSData+KSCrashGZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+KSCrashGZip.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.m"; sourceTree = "<group>"; };
 		CB8E56E317EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+KSCrashSimpleConstructor.h"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.h"; sourceTree = "<group>"; };
 		CB8E56E417EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+KSCrashSimpleConstructor.m"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.m"; sourceTree = "<group>"; };
-		CB8E56E517EB9B89000C56D3 /* NSMutableData+AppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableData+AppendUTF8.h"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.h"; sourceTree = "<group>"; };
-		CB8E56E617EB9B89000C56D3 /* NSMutableData+AppendUTF8.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+AppendUTF8.m"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.m"; sourceTree = "<group>"; };
+		CB8E56E517EB9B89000C56D3 /* NSMutableData+KSCrashAppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableData+KSCrashAppendUTF8.h"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+KSCrashAppendUTF8.h"; sourceTree = "<group>"; };
+		CB8E56E617EB9B89000C56D3 /* NSMutableData+KSCrashAppendUTF8.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+KSCrashAppendUTF8.m"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+KSCrashAppendUTF8.m"; sourceTree = "<group>"; };
 		CB8E56FD17EB9B95000C56D3 /* KSCrashDoctor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashDoctor.h; path = ../../Source/KSCrash/Recording/KSCrashDoctor.h; sourceTree = "<group>"; };
 		CB8E56FE17EB9B95000C56D3 /* KSCrashDoctor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashDoctor.m; path = ../../Source/KSCrash/Recording/KSCrashDoctor.m; sourceTree = "<group>"; };
 		CB8E56FF17EB9B95000C56D3 /* KSCrashReportStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashReportStore.h; path = ../../Source/KSCrash/Recording/KSCrashReportStore.h; sourceTree = "<group>"; };
@@ -871,7 +871,7 @@
 				CB7A6CBC17FB9CEE00997792 /* KSZombie_Tests.m */,
 				CB7A6CBD17FB9CEE00997792 /* NSData+Gzip_Tests.m */,
 				CB7A6CBF17FB9CEE00997792 /* NSError+KSCrashSimpleConstructor_Tests.m */,
-				CB7A6CC017FB9CEE00997792 /* NSMutableData+AppendUTF8_Tests.m */,
+				CB7A6CC017FB9CEE00997792 /* NSMutableData+KSCrashAppendUTF8_Tests.m */,
 				CB25A5D01DF22B2300EC2B02 /* TestThread.h */,
 				CB25A5D11DF22B2300EC2B02 /* TestThread.m */,
 				CB7A6CC217FB9CEE00997792 /* XCTestCase+KSCrash.h */,
@@ -1074,8 +1074,8 @@
 				CB8E56DA17EB9B89000C56D3 /* KSHTTPRequestSender.m */,
 				CB8E56DB17EB9B89000C56D3 /* KSReachabilityKSCrash.h */,
 				CB8E56DC17EB9B89000C56D3 /* KSReachabilityKSCrash.m */,
-				CB8E56E517EB9B89000C56D3 /* NSMutableData+AppendUTF8.h */,
-				CB8E56E617EB9B89000C56D3 /* NSMutableData+AppendUTF8.m */,
+				CB8E56E517EB9B89000C56D3 /* NSMutableData+KSCrashAppendUTF8.h */,
+				CB8E56E617EB9B89000C56D3 /* NSMutableData+KSCrashAppendUTF8.m */,
 				CBEE5DC61CBC19AF005EAF61 /* NSString+KSCrashURLEncode.h */,
 				CBEE5DC71CBC19AF005EAF61 /* NSString+KSCrashURLEncode.m */,
 			);
@@ -1165,7 +1165,7 @@
 				CB6240BB17EBCA74006471F1 /* KSCrashMonitor_Deadlock.h in Headers */,
 				CB62411617EBCA74006471F1 /* NSError+KSCrashSimpleConstructor.h in Headers */,
 				CB9821B11DFA070300164220 /* KSMachineContext_Apple.h in Headers */,
-				CB62411817EBCA74006471F1 /* NSMutableData+AppendUTF8.h in Headers */,
+				CB62411817EBCA74006471F1 /* NSMutableData+KSCrashAppendUTF8.h in Headers */,
 				CB6240B917EBCA74006471F1 /* KSCrashMonitor_CPPException.h in Headers */,
 				CB6240BF17EBCA74006471F1 /* KSCrashMonitor_NSException.h in Headers */,
 				CB5657FC1E1DD424005A8302 /* KSSymbolicator.h in Headers */,
@@ -1277,7 +1277,7 @@
 				CB2686291C694E4400EE4EB3 /* Malloc.h in Headers */,
 				CB2686151C694E4400EE4EB3 /* llvm-config.h in Headers */,
 				CB9821B01DFA070300164220 /* KSMachineContext_Apple.h in Headers */,
-				CB8E56FB17EB9B89000C56D3 /* NSMutableData+AppendUTF8.h in Headers */,
+				CB8E56FB17EB9B89000C56D3 /* NSMutableData+KSCrashAppendUTF8.h in Headers */,
 				CB8E565417EB9B35000C56D3 /* KSCrashMonitor_NSException.h in Headers */,
 				CB25A5C11DF2209000EC2B02 /* KSCPU.h in Headers */,
 				CBBD3AAE1CAD98A300DBB897 /* KSCrashInstallationConsole.h in Headers */,
@@ -1509,7 +1509,7 @@
 				CBA8A0D01E25D3760019B5B9 /* KSCrashCachedData.c in Sources */,
 				CB62410517EBCA74006471F1 /* Container+DeepSearch.m in Sources */,
 				CB2686211C694E4400EE4EB3 /* Demangle.cpp in Sources */,
-				CB62411917EBCA74006471F1 /* NSMutableData+AppendUTF8.m in Sources */,
+				CB62411917EBCA74006471F1 /* NSMutableData+KSCrashAppendUTF8.m in Sources */,
 				CB6240C017EBCA74006471F1 /* KSCrashMonitor_NSException.m in Sources */,
 				CB62411C17EBCA74006471F1 /* KSCrashInstallation.m in Sources */,
 				CB6240B217EBCA74006471F1 /* KSCrashMonitorType.c in Sources */,
@@ -1608,7 +1608,7 @@
 				CB25A5E11DF236D500EC2B02 /* KSThread.c in Sources */,
 				CB8E571817EB9BA8000C56D3 /* KSCrashInstallationStandard.m in Sources */,
 				CB25A5F91DF23B5D00EC2B02 /* KSDebug.c in Sources */,
-				CB8E56FC17EB9B89000C56D3 /* NSMutableData+AppendUTF8.m in Sources */,
+				CB8E56FC17EB9B89000C56D3 /* NSMutableData+KSCrashAppendUTF8.m in Sources */,
 				CB8E565917EB9B35000C56D3 /* KSCrashMonitor_User.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1617,7 +1617,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CB7A6CE617FB9CEE00997792 /* NSMutableData+AppendUTF8_Tests.m in Sources */,
+				CB7A6CE617FB9CEE00997792 /* NSMutableData+KSCrashAppendUTF8_Tests.m in Sources */,
 				CB7A6CC917FB9CEE00997792 /* KSCrashInstallationVictory_Tests.m in Sources */,
 				CB7A6CD117FB9CEE00997792 /* KSCrashSentry_NSException_Tests.m in Sources */,
 				CB7A6CE817FB9CEE00997792 /* XCTestCase+KSCrash.m in Sources */,

--- a/Mac/KSCrash-Mac.xcodeproj/project.pbxproj
+++ b/Mac/KSCrash-Mac.xcodeproj/project.pbxproj
@@ -387,10 +387,10 @@
 		CBC7CCF51DA70FF6002D5DAD /* KSCrashMonitor_Zombie.c in Sources */ = {isa = PBXBuildFile; fileRef = 03082CD41D9181F600935324 /* KSCrashMonitor_Zombie.c */; };
 		CBEE5C1B1CB86674005EAF61 /* KSSystemCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C1A1CB86674005EAF61 /* KSSystemCapabilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBEE5C1C1CB86674005EAF61 /* KSSystemCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C1A1CB86674005EAF61 /* KSSystemCapabilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBEE5DC81CBC19AF005EAF61 /* NSString+URLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC61CBC19AF005EAF61 /* NSString+URLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBEE5DC91CBC19AF005EAF61 /* NSString+URLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC61CBC19AF005EAF61 /* NSString+URLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBEE5DCA1CBC19AF005EAF61 /* NSString+URLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DC71CBC19AF005EAF61 /* NSString+URLEncode.m */; };
-		CBEE5DCB1CBC19AF005EAF61 /* NSString+URLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DC71CBC19AF005EAF61 /* NSString+URLEncode.m */; };
+		CBEE5DC81CBC19AF005EAF61 /* NSString+KSCrashURLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC61CBC19AF005EAF61 /* NSString+KSCrashURLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBEE5DC91CBC19AF005EAF61 /* NSString+KSCrashURLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC61CBC19AF005EAF61 /* NSString+KSCrashURLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBEE5DCA1CBC19AF005EAF61 /* NSString+KSCrashURLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DC71CBC19AF005EAF61 /* NSString+KSCrashURLEncode.m */; };
+		CBEE5DCB1CBC19AF005EAF61 /* NSString+KSCrashURLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DC71CBC19AF005EAF61 /* NSString+KSCrashURLEncode.m */; };
 		CD3DA41A1CD70F070037EB76 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CD3DA4191CD70F070037EB76 /* libz.tbd */; };
 		CD3DA41B1CD70F0D0037EB76 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB8E571D17EBA8DF000C56D3 /* SystemConfiguration.framework */; };
 		DCA19E3418832A7800DCA792 /* KSCrashMonitor_MachException.c in Sources */ = {isa = PBXBuildFile; fileRef = DCA19E3318832A7700DCA792 /* KSCrashMonitor_MachException.c */; };
@@ -634,8 +634,8 @@
 		CBBD3AAC1CAD98A300DBB897 /* KSCrashInstallationConsole.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashInstallationConsole.h; path = ../../Source/KSCrash/Installations/KSCrashInstallationConsole.h; sourceTree = "<group>"; };
 		CBBD3AAD1CAD98A300DBB897 /* KSCrashInstallationConsole.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashInstallationConsole.m; path = ../../Source/KSCrash/Installations/KSCrashInstallationConsole.m; sourceTree = "<group>"; };
 		CBEE5C1A1CB86674005EAF61 /* KSSystemCapabilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSSystemCapabilities.h; path = ../../Source/KSCrash/Recording/KSSystemCapabilities.h; sourceTree = "<group>"; };
-		CBEE5DC61CBC19AF005EAF61 /* NSString+URLEncode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+URLEncode.h"; path = "../../Source/KSCrash/Reporting/Tools/NSString+URLEncode.h"; sourceTree = "<group>"; };
-		CBEE5DC71CBC19AF005EAF61 /* NSString+URLEncode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+URLEncode.m"; path = "../../Source/KSCrash/Reporting/Tools/NSString+URLEncode.m"; sourceTree = "<group>"; };
+		CBEE5DC61CBC19AF005EAF61 /* NSString+KSCrashURLEncode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+KSCrashURLEncode.h"; path = "../../Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.h"; sourceTree = "<group>"; };
+		CBEE5DC71CBC19AF005EAF61 /* NSString+KSCrashURLEncode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+KSCrashURLEncode.m"; path = "../../Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.m"; sourceTree = "<group>"; };
 		CD3DA4191CD70F070037EB76 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		DCA19E3318832A7700DCA792 /* KSCrashMonitor_MachException.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = KSCrashMonitor_MachException.c; path = ../../Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1076,8 +1076,8 @@
 				CB8E56DC17EB9B89000C56D3 /* KSReachabilityKSCrash.m */,
 				CB8E56E517EB9B89000C56D3 /* NSMutableData+AppendUTF8.h */,
 				CB8E56E617EB9B89000C56D3 /* NSMutableData+AppendUTF8.m */,
-				CBEE5DC61CBC19AF005EAF61 /* NSString+URLEncode.h */,
-				CBEE5DC71CBC19AF005EAF61 /* NSString+URLEncode.m */,
+				CBEE5DC61CBC19AF005EAF61 /* NSString+KSCrashURLEncode.h */,
+				CBEE5DC71CBC19AF005EAF61 /* NSString+KSCrashURLEncode.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -1147,7 +1147,7 @@
 				CB6240F617EBCA74006471F1 /* KSCrashReportSinkConsole.h in Headers */,
 				CB6240F817EBCA74006471F1 /* KSCrashReportSinkEMail.h in Headers */,
 				CB6240FA17EBCA74006471F1 /* KSCrashReportSinkQuincyHockey.h in Headers */,
-				CBEE5DC91CBC19AF005EAF61 /* NSString+URLEncode.h in Headers */,
+				CBEE5DC91CBC19AF005EAF61 /* NSString+KSCrashURLEncode.h in Headers */,
 				CB6240FC17EBCA74006471F1 /* KSCrashReportSinkStandard.h in Headers */,
 				CB69B8D41DC04432002713B1 /* KSDate.h in Headers */,
 				CBEE5C1C1CB86674005EAF61 /* KSSystemCapabilities.h in Headers */,
@@ -1258,7 +1258,7 @@
 				CBA8A0D11E25D3760019B5B9 /* KSCrashCachedData.h in Headers */,
 				CB8E56CF17EB9B7E000C56D3 /* KSCrashReportSinkVictory.h in Headers */,
 				CB8E570317EB9B95000C56D3 /* KSCrashReportStore.h in Headers */,
-				CBEE5DC81CBC19AF005EAF61 /* NSString+URLEncode.h in Headers */,
+				CBEE5DC81CBC19AF005EAF61 /* NSString+KSCrashURLEncode.h in Headers */,
 				CB26860F1C694E4400EE4EB3 /* None.h in Headers */,
 				CBEE5C1B1CB86674005EAF61 /* KSSystemCapabilities.h in Headers */,
 				CB8E563317EB9AFD000C56D3 /* KSCrashReportWriter.h in Headers */,
@@ -1501,7 +1501,7 @@
 				CBC7CCF51DA70FF6002D5DAD /* KSCrashMonitor_Zombie.c in Sources */,
 				CB6240F717EBCA74006471F1 /* KSCrashReportSinkConsole.m in Sources */,
 				CB18069D1E0DA09B00239506 /* KSStackCursor_Backtrace.c in Sources */,
-				CBEE5DCB1CBC19AF005EAF61 /* NSString+URLEncode.m in Sources */,
+				CBEE5DCB1CBC19AF005EAF61 /* NSString+KSCrashURLEncode.m in Sources */,
 				CB62412617EBCA74006471F1 /* KSCrash.m in Sources */,
 				CB6240CD17EBCA74006471F1 /* KSJSONCodec.c in Sources */,
 				CBA1A5311DD24FB5007B1CE7 /* KSDemangle_Swift.cpp in Sources */,
@@ -1584,7 +1584,7 @@
 				CB18069C1E0DA09B00239506 /* KSStackCursor_Backtrace.c in Sources */,
 				CB8E570217EB9B95000C56D3 /* KSCrashDoctor.m in Sources */,
 				CB8E569517EB9B43000C56D3 /* KSSignalInfo.c in Sources */,
-				CBEE5DCA1CBC19AF005EAF61 /* NSString+URLEncode.m in Sources */,
+				CBEE5DCA1CBC19AF005EAF61 /* NSString+KSCrashURLEncode.m in Sources */,
 				CBA1A5301DD24FB5007B1CE7 /* KSDemangle_Swift.cpp in Sources */,
 				CB8E568217EB9B43000C56D3 /* KSFileUtils.c in Sources */,
 				CBA8A0CF1E25D3760019B5B9 /* KSCrashCachedData.c in Sources */,

--- a/Mac/KSCrash-Mac.xcodeproj/project.pbxproj
+++ b/Mac/KSCrash-Mac.xcodeproj/project.pbxproj
@@ -161,8 +161,8 @@
 		CB62410017EBCA74006471F1 /* KSCrashDoctor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56FD17EB9B95000C56D3 /* KSCrashDoctor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB62410117EBCA74006471F1 /* KSCrashDoctor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56FE17EB9B95000C56D3 /* KSCrashDoctor.m */; };
 		CB62410217EBCA74006471F1 /* KSCrashReportStore.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56FF17EB9B95000C56D3 /* KSCrashReportStore.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CB62410417EBCA74006471F1 /* Container+DeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56D117EB9B89000C56D3 /* Container+DeepSearch.h */; };
-		CB62410517EBCA74006471F1 /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56D217EB9B89000C56D3 /* Container+DeepSearch.m */; };
+		CB62410417EBCA74006471F1 /* Container+KSCrashDeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56D117EB9B89000C56D3 /* Container+KSCrashDeepSearch.h */; };
+		CB62410517EBCA74006471F1 /* Container+KSCrashDeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56D217EB9B89000C56D3 /* Container+KSCrashDeepSearch.m */; };
 		CB62410817EBCA74006471F1 /* KSCString.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56D517EB9B89000C56D3 /* KSCString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB62410917EBCA74006471F1 /* KSCString.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56D617EB9B89000C56D3 /* KSCString.m */; };
 		CB62410A17EBCA74006471F1 /* KSHTTPMultipartPostBody.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56D717EB9B89000C56D3 /* KSHTTPMultipartPostBody.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -202,7 +202,7 @@
 		CB7A6C9617FB99E800997792 /* KSDynamicLinker.c in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6C9417FB99E800997792 /* KSDynamicLinker.c */; };
 		CB7A6C9817FB99E800997792 /* KSDynamicLinker.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7A6C9517FB99E800997792 /* KSDynamicLinker.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB7A6C9917FB9A1000997792 /* KSDynamicLinker.c in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6C9417FB99E800997792 /* KSDynamicLinker.c */; };
-		CB7A6CC417FB9CEE00997792 /* Container+DeepSearch_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6C9D17FB9CEE00997792 /* Container+DeepSearch_Tests.m */; };
+		CB7A6CC417FB9CEE00997792 /* Container+KSCrashDeepSearch_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6C9D17FB9CEE00997792 /* Container+KSCrashDeepSearch_Tests.m */; };
 		CB7A6CC517FB9CEE00997792 /* FileBasedTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6C9F17FB9CEE00997792 /* FileBasedTestCase.m */; };
 		CB7A6CC617FB9CEE00997792 /* KSCrashInstallationEmail_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CA017FB9CEE00997792 /* KSCrashInstallationEmail_Tests.m */; };
 		CB7A6CC717FB9CEE00997792 /* KSCrashInstallationQuincyHockey_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7A6CA117FB9CEE00997792 /* KSCrashInstallationQuincyHockey_Tests.m */; };
@@ -313,8 +313,8 @@
 		CB8E56CE17EB9B7E000C56D3 /* KSCrashReportSinkStandard.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56B617EB9B7E000C56D3 /* KSCrashReportSinkStandard.m */; };
 		CB8E56CF17EB9B7E000C56D3 /* KSCrashReportSinkVictory.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56B717EB9B7E000C56D3 /* KSCrashReportSinkVictory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB8E56D017EB9B7E000C56D3 /* KSCrashReportSinkVictory.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56B817EB9B7E000C56D3 /* KSCrashReportSinkVictory.m */; };
-		CB8E56E717EB9B89000C56D3 /* Container+DeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56D117EB9B89000C56D3 /* Container+DeepSearch.h */; };
-		CB8E56E817EB9B89000C56D3 /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56D217EB9B89000C56D3 /* Container+DeepSearch.m */; };
+		CB8E56E717EB9B89000C56D3 /* Container+KSCrashDeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56D117EB9B89000C56D3 /* Container+KSCrashDeepSearch.h */; };
+		CB8E56E817EB9B89000C56D3 /* Container+KSCrashDeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56D217EB9B89000C56D3 /* Container+KSCrashDeepSearch.m */; };
 		CB8E56EB17EB9B89000C56D3 /* KSCString.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56D517EB9B89000C56D3 /* KSCString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB8E56EC17EB9B89000C56D3 /* KSCString.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56D617EB9B89000C56D3 /* KSCString.m */; };
 		CB8E56ED17EB9B89000C56D3 /* KSHTTPMultipartPostBody.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56D717EB9B89000C56D3 /* KSHTTPMultipartPostBody.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -461,7 +461,7 @@
 		CB69B8E81DC0F17A002713B1 /* KSCrashReportStore.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = KSCrashReportStore.c; path = ../../Source/KSCrash/Recording/KSCrashReportStore.c; sourceTree = "<group>"; };
 		CB7A6C9417FB99E800997792 /* KSDynamicLinker.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = KSDynamicLinker.c; path = ../../Source/KSCrash/Recording/Tools/KSDynamicLinker.c; sourceTree = "<group>"; };
 		CB7A6C9517FB99E800997792 /* KSDynamicLinker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSDynamicLinker.h; path = ../../Source/KSCrash/Recording/Tools/KSDynamicLinker.h; sourceTree = "<group>"; };
-		CB7A6C9D17FB9CEE00997792 /* Container+DeepSearch_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+DeepSearch_Tests.m"; path = "../../Source/KSCrash-Tests/Container+DeepSearch_Tests.m"; sourceTree = "<group>"; };
+		CB7A6C9D17FB9CEE00997792 /* Container+KSCrashDeepSearch_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+KSCrashDeepSearch_Tests.m"; path = "../../Source/KSCrash-Tests/Container+KSCrashDeepSearch_Tests.m"; sourceTree = "<group>"; };
 		CB7A6C9E17FB9CEE00997792 /* FileBasedTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FileBasedTestCase.h; path = "../../Source/KSCrash-Tests/FileBasedTestCase.h"; sourceTree = "<group>"; };
 		CB7A6C9F17FB9CEE00997792 /* FileBasedTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FileBasedTestCase.m; path = "../../Source/KSCrash-Tests/FileBasedTestCase.m"; sourceTree = "<group>"; };
 		CB7A6CA017FB9CEE00997792 /* KSCrashInstallationEmail_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashInstallationEmail_Tests.m; path = "../../Source/KSCrash-Tests/KSCrashInstallationEmail_Tests.m"; sourceTree = "<group>"; };
@@ -581,8 +581,8 @@
 		CB8E56B617EB9B7E000C56D3 /* KSCrashReportSinkStandard.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashReportSinkStandard.m; path = ../../Source/KSCrash/Reporting/Sinks/KSCrashReportSinkStandard.m; sourceTree = "<group>"; };
 		CB8E56B717EB9B7E000C56D3 /* KSCrashReportSinkVictory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashReportSinkVictory.h; path = ../../Source/KSCrash/Reporting/Sinks/KSCrashReportSinkVictory.h; sourceTree = "<group>"; };
 		CB8E56B817EB9B7E000C56D3 /* KSCrashReportSinkVictory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashReportSinkVictory.m; path = ../../Source/KSCrash/Reporting/Sinks/KSCrashReportSinkVictory.m; sourceTree = "<group>"; };
-		CB8E56D117EB9B89000C56D3 /* Container+DeepSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Container+DeepSearch.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+DeepSearch.h"; sourceTree = "<group>"; };
-		CB8E56D217EB9B89000C56D3 /* Container+DeepSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+DeepSearch.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+DeepSearch.m"; sourceTree = "<group>"; };
+		CB8E56D117EB9B89000C56D3 /* Container+KSCrashDeepSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Container+KSCrashDeepSearch.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+KSCrashDeepSearch.h"; sourceTree = "<group>"; };
+		CB8E56D217EB9B89000C56D3 /* Container+KSCrashDeepSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+KSCrashDeepSearch.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+KSCrashDeepSearch.m"; sourceTree = "<group>"; };
 		CB8E56D517EB9B89000C56D3 /* KSCString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCString.h; path = ../../Source/KSCrash/Reporting/Tools/KSCString.h; sourceTree = "<group>"; };
 		CB8E56D617EB9B89000C56D3 /* KSCString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCString.m; path = ../../Source/KSCrash/Reporting/Tools/KSCString.m; sourceTree = "<group>"; };
 		CB8E56D717EB9B89000C56D3 /* KSHTTPMultipartPostBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSHTTPMultipartPostBody.h; path = ../../Source/KSCrash/Reporting/Tools/KSHTTPMultipartPostBody.h; sourceTree = "<group>"; };
@@ -837,7 +837,7 @@
 		CB8E560517EB99E3000C56D3 /* KSCrashTests */ = {
 			isa = PBXGroup;
 			children = (
-				CB7A6C9D17FB9CEE00997792 /* Container+DeepSearch_Tests.m */,
+				CB7A6C9D17FB9CEE00997792 /* Container+KSCrashDeepSearch_Tests.m */,
 				CB7A6C9E17FB9CEE00997792 /* FileBasedTestCase.h */,
 				CB7A6C9F17FB9CEE00997792 /* FileBasedTestCase.m */,
 				CB7A6CA017FB9CEE00997792 /* KSCrashInstallationEmail_Tests.m */,
@@ -1102,8 +1102,8 @@
 		DCA19E37188338C400DCA792 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
-				CB8E56D117EB9B89000C56D3 /* Container+DeepSearch.h */,
-				CB8E56D217EB9B89000C56D3 /* Container+DeepSearch.m */,
+				CB8E56D117EB9B89000C56D3 /* Container+KSCrashDeepSearch.h */,
+				CB8E56D217EB9B89000C56D3 /* Container+KSCrashDeepSearch.m */,
 				CB8E56DE17EB9B89000C56D3 /* KSVarArgs.h */,
 				CB8E56DF17EB9B89000C56D3 /* NSData+KSCrashGZip.h */,
 				CB8E56E017EB9B89000C56D3 /* NSData+KSCrashGZip.m */,
@@ -1198,7 +1198,7 @@
 				CB62411A17EBCA74006471F1 /* KSCrashInstallation+Private.h in Headers */,
 				CB26862A1C694E4400EE4EB3 /* Malloc.h in Headers */,
 				CB2686141C694E4400EE4EB3 /* StringRef.h in Headers */,
-				CB62410417EBCA74006471F1 /* Container+DeepSearch.h in Headers */,
+				CB62410417EBCA74006471F1 /* Container+KSCrashDeepSearch.h in Headers */,
 				CB62410A17EBCA74006471F1 /* KSHTTPMultipartPostBody.h in Headers */,
 				CBA1A5271DD24F8D007B1CE7 /* KSCrashReportFixer.h in Headers */,
 				CB6240C317EBCA74006471F1 /* KSCrashMonitor_Signal.h in Headers */,
@@ -1302,7 +1302,7 @@
 				CB8E568317EB9B43000C56D3 /* KSFileUtils.h in Headers */,
 				CB8E565817EB9B35000C56D3 /* KSCrashMonitor_Signal.h in Headers */,
 				CB2686271C694E4400EE4EB3 /* LLVM.h in Headers */,
-				CB8E56E717EB9B89000C56D3 /* Container+DeepSearch.h in Headers */,
+				CB8E56E717EB9B89000C56D3 /* Container+KSCrashDeepSearch.h in Headers */,
 				CB25A60A1DF23F0C00EC2B02 /* KSCPU_Apple.h in Headers */,
 				CB8E563217EB9AFD000C56D3 /* KSCrashReportFields.h in Headers */,
 				CB26861A1C694E4400EE4EB3 /* Casting.h in Headers */,
@@ -1507,7 +1507,7 @@
 				CBA1A5311DD24FB5007B1CE7 /* KSDemangle_Swift.cpp in Sources */,
 				CB6240C217EBCA74006471F1 /* KSCrashMonitor_Signal.c in Sources */,
 				CBA8A0D01E25D3760019B5B9 /* KSCrashCachedData.c in Sources */,
-				CB62410517EBCA74006471F1 /* Container+DeepSearch.m in Sources */,
+				CB62410517EBCA74006471F1 /* Container+KSCrashDeepSearch.m in Sources */,
 				CB2686211C694E4400EE4EB3 /* Demangle.cpp in Sources */,
 				CB62411917EBCA74006471F1 /* NSMutableData+KSCrashAppendUTF8.m in Sources */,
 				CB6240C017EBCA74006471F1 /* KSCrashMonitor_NSException.m in Sources */,
@@ -1579,7 +1579,7 @@
 				CB8E56FA17EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m in Sources */,
 				CB8F1DD41CCAF3B40022CDF0 /* KSCrashInstallation+Alert.m in Sources */,
 				CB69B8DE1DC0F106002713B1 /* KSLogger.c in Sources */,
-				CB8E56E817EB9B89000C56D3 /* Container+DeepSearch.m in Sources */,
+				CB8E56E817EB9B89000C56D3 /* Container+KSCrashDeepSearch.m in Sources */,
 				03082CD51D9181F600935324 /* KSCrashMonitor_Zombie.c in Sources */,
 				CB18069C1E0DA09B00239506 /* KSStackCursor_Backtrace.c in Sources */,
 				CB8E570217EB9B95000C56D3 /* KSCrashDoctor.m in Sources */,
@@ -1633,7 +1633,7 @@
 				CB7A6CD317FB9CEE00997792 /* KSCrashSentry_Tests.m in Sources */,
 				CB7A6CD617FB9CEE00997792 /* KSCString_Tests.m in Sources */,
 				CB7A6CE017FB9CEE00997792 /* KSSysCtl_Tests.m in Sources */,
-				CB7A6CC417FB9CEE00997792 /* Container+DeepSearch_Tests.m in Sources */,
+				CB7A6CC417FB9CEE00997792 /* Container+KSCrashDeepSearch_Tests.m in Sources */,
 				CB7A6CCA17FB9CEE00997792 /* KSCrashReportConverter_Tests.m in Sources */,
 				CB7A6CC717FB9CEE00997792 /* KSCrashInstallationQuincyHockey_Tests.m in Sources */,
 				CB7A6CDC17FB9CEE00997792 /* KSObjC_Tests.m in Sources */,

--- a/Mac/KSCrash-Mac.xcodeproj/project.pbxproj
+++ b/Mac/KSCrash-Mac.xcodeproj/project.pbxproj
@@ -172,8 +172,8 @@
 		CB62410E17EBCA74006471F1 /* KSReachabilityKSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56DB17EB9B89000C56D3 /* KSReachabilityKSCrash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB62410F17EBCA74006471F1 /* KSReachabilityKSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56DC17EB9B89000C56D3 /* KSReachabilityKSCrash.m */; };
 		CB62411117EBCA74006471F1 /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56DE17EB9B89000C56D3 /* KSVarArgs.h */; };
-		CB62411217EBCA74006471F1 /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56DF17EB9B89000C56D3 /* NSData+GZip.h */; };
-		CB62411317EBCA74006471F1 /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E017EB9B89000C56D3 /* NSData+GZip.m */; };
+		CB62411217EBCA74006471F1 /* NSData+KSCrashGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56DF17EB9B89000C56D3 /* NSData+KSCrashGZip.h */; };
+		CB62411317EBCA74006471F1 /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E017EB9B89000C56D3 /* NSData+KSCrashGZip.m */; };
 		CB62411617EBCA74006471F1 /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E317EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB62411717EBCA74006471F1 /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E417EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m */; };
 		CB62411817EBCA74006471F1 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E517EB9B89000C56D3 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -324,8 +324,8 @@
 		CB8E56F117EB9B89000C56D3 /* KSReachabilityKSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56DB17EB9B89000C56D3 /* KSReachabilityKSCrash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB8E56F217EB9B89000C56D3 /* KSReachabilityKSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56DC17EB9B89000C56D3 /* KSReachabilityKSCrash.m */; };
 		CB8E56F417EB9B89000C56D3 /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56DE17EB9B89000C56D3 /* KSVarArgs.h */; };
-		CB8E56F517EB9B89000C56D3 /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56DF17EB9B89000C56D3 /* NSData+GZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CB8E56F617EB9B89000C56D3 /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E017EB9B89000C56D3 /* NSData+GZip.m */; };
+		CB8E56F517EB9B89000C56D3 /* NSData+KSCrashGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56DF17EB9B89000C56D3 /* NSData+KSCrashGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB8E56F617EB9B89000C56D3 /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E017EB9B89000C56D3 /* NSData+KSCrashGZip.m */; };
 		CB8E56F917EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E317EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB8E56FA17EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E56E417EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m */; };
 		CB8E56FB17EB9B89000C56D3 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E56E517EB9B89000C56D3 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -592,8 +592,8 @@
 		CB8E56DB17EB9B89000C56D3 /* KSReachabilityKSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSReachabilityKSCrash.h; path = ../../Source/KSCrash/Reporting/Tools/KSReachabilityKSCrash.h; sourceTree = "<group>"; };
 		CB8E56DC17EB9B89000C56D3 /* KSReachabilityKSCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSReachabilityKSCrash.m; path = ../../Source/KSCrash/Reporting/Tools/KSReachabilityKSCrash.m; sourceTree = "<group>"; };
 		CB8E56DE17EB9B89000C56D3 /* KSVarArgs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSVarArgs.h; path = ../../Source/KSCrash/Reporting/Filters/Tools/KSVarArgs.h; sourceTree = "<group>"; };
-		CB8E56DF17EB9B89000C56D3 /* NSData+GZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+GZip.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.h"; sourceTree = "<group>"; };
-		CB8E56E017EB9B89000C56D3 /* NSData+GZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+GZip.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.m"; sourceTree = "<group>"; };
+		CB8E56DF17EB9B89000C56D3 /* NSData+KSCrashGZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+KSCrashGZip.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.h"; sourceTree = "<group>"; };
+		CB8E56E017EB9B89000C56D3 /* NSData+KSCrashGZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+KSCrashGZip.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.m"; sourceTree = "<group>"; };
 		CB8E56E317EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+KSCrashSimpleConstructor.h"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.h"; sourceTree = "<group>"; };
 		CB8E56E417EB9B89000C56D3 /* NSError+KSCrashSimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+KSCrashSimpleConstructor.m"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.m"; sourceTree = "<group>"; };
 		CB8E56E517EB9B89000C56D3 /* NSMutableData+AppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableData+AppendUTF8.h"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.h"; sourceTree = "<group>"; };
@@ -1105,8 +1105,8 @@
 				CB8E56D117EB9B89000C56D3 /* Container+DeepSearch.h */,
 				CB8E56D217EB9B89000C56D3 /* Container+DeepSearch.m */,
 				CB8E56DE17EB9B89000C56D3 /* KSVarArgs.h */,
-				CB8E56DF17EB9B89000C56D3 /* NSData+GZip.h */,
-				CB8E56E017EB9B89000C56D3 /* NSData+GZip.m */,
+				CB8E56DF17EB9B89000C56D3 /* NSData+KSCrashGZip.h */,
+				CB8E56E017EB9B89000C56D3 /* NSData+KSCrashGZip.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -1182,7 +1182,7 @@
 				CB2686261C694E4400EE4EB3 /* Fallthrough.h in Headers */,
 				CB6240CE17EBCA74006471F1 /* KSJSONCodec.h in Headers */,
 				CB6240B817EBCA74006471F1 /* KSCrashMonitor.h in Headers */,
-				CB62411217EBCA74006471F1 /* NSData+GZip.h in Headers */,
+				CB62411217EBCA74006471F1 /* NSData+KSCrashGZip.h in Headers */,
 				CB25A60B1DF23F0C00EC2B02 /* KSCPU_Apple.h in Headers */,
 				CB6240B417EBCA74006471F1 /* KSCrashMonitor_System.h in Headers */,
 				CB6240DF17EBCA74006471F1 /* KSSignalInfo.h in Headers */,
@@ -1224,7 +1224,7 @@
 				CB8E563817EB9AFD000C56D3 /* KSCrashMonitor_System.h in Headers */,
 				CB1806A61E0DA09B00239506 /* KSStackCursor.h in Headers */,
 				CB8E571017EB9BA8000C56D3 /* KSCrashInstallation+Private.h in Headers */,
-				CB8E56F517EB9B89000C56D3 /* NSData+GZip.h in Headers */,
+				CB8E56F517EB9B89000C56D3 /* NSData+KSCrashGZip.h in Headers */,
 				CB8F1DD21CCAF3B40022CDF0 /* KSCrashInstallation+Alert.h in Headers */,
 				CB5657F71E1DD424005A8302 /* KSStackCursor_SelfThread.h in Headers */,
 				CB8E561817EB9AA5000C56D3 /* KSCrash.h in Headers */,
@@ -1482,7 +1482,7 @@
 				CB6240D317EBCA74006471F1 /* KSMemory.c in Sources */,
 				CB9821CB1DFB429700164220 /* KSMach.c in Sources */,
 				CB6240DE17EBCA74006471F1 /* KSSignalInfo.c in Sources */,
-				CB62411317EBCA74006471F1 /* NSData+GZip.m in Sources */,
+				CB62411317EBCA74006471F1 /* NSData+KSCrashGZip.m in Sources */,
 				CB6240AC17EBCA74006471F1 /* KSCrashReport.c in Sources */,
 				CB6240C417EBCA74006471F1 /* KSCrashMonitor_User.c in Sources */,
 				CB6240D617EBCA74006471F1 /* KSCPU_x86_32.c in Sources */,
@@ -1595,7 +1595,7 @@
 				CB2686201C694E4400EE4EB3 /* Demangle.cpp in Sources */,
 				CB9821AE1DFA070300164220 /* KSMachineContext.c in Sources */,
 				CB5657F91E1DD424005A8302 /* KSSymbolicator.c in Sources */,
-				CB8E56F617EB9B89000C56D3 /* NSData+GZip.m in Sources */,
+				CB8E56F617EB9B89000C56D3 /* NSData+KSCrashGZip.m in Sources */,
 				CB69B8E91DC0F17A002713B1 /* KSCrashReportStore.c in Sources */,
 				CB1806A01E0DA09B00239506 /* KSStackCursor_MachineContext.c in Sources */,
 				CB8E56EC17EB9B89000C56D3 /* KSCString.m in Sources */,

--- a/Source/Framework/KSCrashAblyForkFramework.h
+++ b/Source/Framework/KSCrashAblyForkFramework.h
@@ -37,6 +37,6 @@
 #import "KSCrashReportSinkVictory.h"
 #import "KSCrashReportWriter.h"
 #import "KSJSONCodecObjC.h"
-#import "NSData+GZip.h"
+#import "NSData+KSCrashGZip.h"
 
 #endif /* KSCrashAblyForkFramework_h */

--- a/Source/KSCrash-Tests/Container+DeepSearch_Tests.m
+++ b/Source/KSCrash-Tests/Container+DeepSearch_Tests.m
@@ -27,7 +27,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "Container+DeepSearch.h"
+#import "Container+KSCrashDeepSearch.h"
 
 
 @interface Container_DeepSearch_Tests : XCTestCase @end

--- a/Source/KSCrash-Tests/KSCrashReportFilterGZip_Tests.m
+++ b/Source/KSCrash-Tests/KSCrashReportFilterGZip_Tests.m
@@ -28,7 +28,7 @@
 #import <XCTest/XCTest.h>
 
 #import "KSCrashReportFilterGZip.h"
-#import "NSData+GZip.h"
+#import "NSData+KSCrashGZip.h"
 
 
 @interface KSCrashReportFilterGZip_Tests : XCTestCase @end
@@ -48,7 +48,7 @@
     NSMutableArray* compressed = [NSMutableArray array];
     for(NSData* data in decompressed)
     {
-        NSData* newData = [data gzippedWithCompressionLevel:-1 error:&error];
+        NSData* newData = [data KSCrashGzippedWithCompressionLevel:-1 error:&error];
         XCTAssertNotNil(newData, @"");
         XCTAssertNil(error, @"");
         [compressed addObject:newData];
@@ -77,7 +77,7 @@
     NSMutableArray* compressed = [NSMutableArray array];
     for(NSData* data in decompressed)
     {
-        NSData* newData = [data gzippedWithCompressionLevel:-1 error:&error];
+        NSData* newData = [data KSCrashGzippedWithCompressionLevel:-1 error:&error];
         XCTAssertNotNil(newData, @"");
         XCTAssertNil(error, @"");
         [compressed addObject:newData];

--- a/Source/KSCrash-Tests/KSCrashReportFilter_Tests.m
+++ b/Source/KSCrash-Tests/KSCrashReportFilter_Tests.m
@@ -32,7 +32,7 @@
 #import "KSCrashReportFilterGZip.h"
 #import "KSCrashReportFilterJSON.h"
 #import "NSData+GZip.h"
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 
 
 @interface KSCrash_TestNilFilter: NSObject <KSCrashReportFilter>

--- a/Source/KSCrash-Tests/KSCrashReportFilter_Tests.m
+++ b/Source/KSCrash-Tests/KSCrashReportFilter_Tests.m
@@ -31,7 +31,7 @@
 #import "KSCrashReportFilterBasic.h"
 #import "KSCrashReportFilterGZip.h"
 #import "KSCrashReportFilterJSON.h"
-#import "NSData+GZip.h"
+#import "NSData+KSCrashGZip.h"
 #import "NSError+KSCrashSimpleConstructor.h"
 
 

--- a/Source/KSCrash-Tests/NSData+Gzip_Tests.m
+++ b/Source/KSCrash-Tests/NSData+Gzip_Tests.m
@@ -26,7 +26,7 @@
 
 
 #import <XCTest/XCTest.h>
-#import "NSData+GZip.h"
+#import "NSData+KSCrashGZip.h"
 
 
 @interface NSData_Gzip_Tests : XCTestCase @end
@@ -46,9 +46,9 @@
 
     NSError* error = nil;
     NSData* original = [NSData dataWithData:data];
-    NSData* compressed = [original gzippedWithCompressionLevel:-1 error:&error];
+    NSData* compressed = [original KSCrashGzippedWithCompressionLevel:-1 error:&error];
     XCTAssertNil(error, @"");
-    NSData* uncompressed = [compressed gunzippedWithError:&error];
+    NSData* uncompressed = [compressed KSCrashGunzippedWithError:&error];
     XCTAssertNil(error, @"");
 
     XCTAssertEqualObjects(uncompressed, original, @"");
@@ -60,9 +60,9 @@
 {
     NSError* error = nil;
     NSData* original = [NSData data];
-    NSData* compressed = [original gzippedWithCompressionLevel:-1 error:&error];
+    NSData* compressed = [original KSCrashGzippedWithCompressionLevel:-1 error:&error];
     XCTAssertNil(error, @"");
-    NSData* uncompressed = [compressed gunzippedWithError:&error];
+    NSData* uncompressed = [compressed KSCrashGunzippedWithError:&error];
     XCTAssertNil(error, @"");
 
     XCTAssertEqualObjects(uncompressed, original, @"");
@@ -80,8 +80,8 @@
     }
 
     NSData* original = [NSData dataWithData:data];
-    NSData* compressed = [original gzippedWithCompressionLevel:-1 error:nil];
-    NSData* uncompressed = [compressed gunzippedWithError:nil];
+    NSData* compressed = [original KSCrashGzippedWithCompressionLevel:-1 error:nil];
+    NSData* uncompressed = [compressed KSCrashGunzippedWithError:nil];
 
     XCTAssertEqualObjects(uncompressed, original, @"");
     XCTAssertFalse([compressed isEqualToData:uncompressed], @"");
@@ -91,8 +91,8 @@
 - (void) testCompressDecompressEmptyNilError
 {
     NSData* original = [NSData data];
-    NSData* compressed = [original gzippedWithCompressionLevel:-1 error:nil];
-    NSData* uncompressed = [compressed gunzippedWithError:nil];
+    NSData* compressed = [original KSCrashGzippedWithCompressionLevel:-1 error:nil];
+    NSData* uncompressed = [compressed KSCrashGunzippedWithError:nil];
 
     XCTAssertEqualObjects(uncompressed, original, @"");
     XCTAssertEqualObjects(compressed, original, @"");

--- a/Source/KSCrash-Tests/NSError+KSCrashSimpleConstructor_Tests.m
+++ b/Source/KSCrash-Tests/NSError+KSCrashSimpleConstructor_Tests.m
@@ -1,5 +1,5 @@
 //
-//  NSError+SimpleConstructor_Tests.m
+//  NSError+KSCrashSimpleConstructor_Tests.m
 //
 //  Created by Karl Stenerud on 2013-03-09.
 //
@@ -27,7 +27,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 
 
 @interface NSError_SimpleConstructor_Tests : XCTestCase @end
@@ -37,7 +37,7 @@
 
 - (void) testErrorWithDomain
 {
-    NSError* error = [NSError errorWithDomain:@"Domain" code:10 description:@"A description %d", 1];
+    NSError* error = [NSError KSCrashErrorWithDomain:@"Domain" code:10 description:@"A description %d", 1];
     NSString* expectedDomain = @"Domain";
     NSInteger expectedCode = 10;
     NSString* expectedDescription = @"A description 1";
@@ -49,7 +49,7 @@
 - (void) testFillError
 {
     NSError* error = nil;
-    [NSError fillError:&error withDomain:@"Domain" code:10 description:@"A description %d", 1];
+    [NSError KSCrashFillError:&error withDomain:@"Domain" code:10 description:@"A description %d", 1];
     NSString* expectedDomain = @"Domain";
     NSInteger expectedCode = 10;
     NSString* expectedDescription = @"A description 1";
@@ -60,14 +60,14 @@
 
 - (void) testFillErrorNil
 {
-    [NSError fillError:nil withDomain:@"Domain" code:10 description:@"A description %d", 1];
+    [NSError KSCrashFillError:nil withDomain:@"Domain" code:10 description:@"A description %d", 1];
 }
 
 - (void) testClearError
 {
-    NSError* error = [NSError errorWithDomain:@"" code:1 description:@""];
+    NSError* error = [NSError KSCrashErrorWithDomain:@"" code:1 description:@""];
     XCTAssertNotNil(error, @"");
-    [NSError clearError:&error];
+    [NSError KSCrashClearError:&error];
     XCTAssertNil(error, @"");
 }
 

--- a/Source/KSCrash-Tests/NSMutableData+AppendUTF8_Tests.m
+++ b/Source/KSCrash-Tests/NSMutableData+AppendUTF8_Tests.m
@@ -27,7 +27,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "NSMutableData+AppendUTF8.h"
+#import "NSMutableData+KSCrashAppendUTF8.h"
 
 
 @interface NSMutableData_AppendUTF8_Tests : XCTestCase @end
@@ -39,7 +39,7 @@
 {
     NSString* expected = @"testテスト";
     NSMutableData* data = [NSMutableData data];
-    [data appendUTF8String:expected];
+    [data KSCrashAppendUTF8String:expected];
     NSString* actual = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 
     XCTAssertEqualObjects(actual, expected, @"");
@@ -49,7 +49,7 @@
 {
     NSString* expected = @"Testing 1 2.0 3";
     NSMutableData* data = [NSMutableData data];
-    [data appendUTF8Format:@"Testing %d %.1f %@", 1, 2.0, @"3"];
+    [data KSCrashAppendUTF8Format:@"Testing %d %.1f %@", 1, 2.0, @"3"];
     NSString* actual = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 
     XCTAssertEqualObjects(actual, expected, @"");

--- a/Source/KSCrash/Installations/KSCrashInstallation.m
+++ b/Source/KSCrash/Installations/KSCrashInstallation.m
@@ -32,7 +32,7 @@
 #import "KSCString.h"
 #import "KSJSONCodecObjC.h"
 #import "KSLogger.h"
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 #import <objc/runtime.h>
 
 
@@ -269,7 +269,7 @@ static void crashCallback(const KSCrashReportWriter* writer)
     }
     if([errors length] > 0)
     {
-        return [NSError errorWithDomain:[[self class] description]
+        return [NSError KSCrashErrorWithDomain:[[self class] description]
                                    code:0
                             description:@"Installation properties failed validation: %@", errors];
     }
@@ -342,7 +342,7 @@ static void crashCallback(const KSCrashReportWriter* writer)
     id<KSCrashReportFilter> sink = [self sink];
     if(sink == nil)
     {
-        onCompletion(nil, NO, [NSError errorWithDomain:[[self class] description]
+        onCompletion(nil, NO, [NSError KSCrashErrorWithDomain:[[self class] description]
                                                   code:0
                                            description:@"Sink was nil (subclasses must implement method \"sink\")"]);
         return;

--- a/Source/KSCrash/Installations/KSCrashInstallationQuincyHockey.m
+++ b/Source/KSCrash/Installations/KSCrashInstallationQuincyHockey.m
@@ -30,7 +30,7 @@
 #import "KSCrashInstallation+Private.h"
 #import "KSCrashReportFields.h"
 #import "KSCrashReportSinkQuincyHockey.h"
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 
 
 #define kQuincyDefaultKeyUserID @"user_id"

--- a/Source/KSCrash/Recording/KSCrash.m
+++ b/Source/KSCrash/Recording/KSCrash.m
@@ -32,7 +32,7 @@
 #import "KSCrashReportFields.h"
 #import "KSCrashMonitor_AppState.h"
 #import "KSJSONCodecObjC.h"
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 #import "KSCrashMonitorContext.h"
 #import "KSCrashMonitor_System.h"
 #import "KSSystemCapabilities.h"
@@ -425,7 +425,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     if(self.sink == nil)
     {
         kscrash_callCompletion(onCompletion, reports, NO,
-                                 [NSError errorWithDomain:[[self class] description]
+                                 [NSError KSCrashErrorWithDomain:[[self class] description]
                                                      code:0
                                               description:@"No sink set. Crash reports not sent."]);
         return;

--- a/Source/KSCrash/Recording/Tools/KSJSONCodecObjC.m
+++ b/Source/KSCrash/Recording/Tools/KSJSONCodecObjC.m
@@ -28,7 +28,7 @@
 #import "KSJSONCodecObjC.h"
 
 #import "KSJSONCodec.h"
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 #import "KSDate.h"
 
 
@@ -167,7 +167,7 @@ static int onElement(KSJSONCodec* codec, NSString* name, id element)
 {
     if(codec->_currentContainer == nil)
     {
-        codec.error = [NSError errorWithDomain:@"KSJSONCodecObjC"
+        codec.error = [NSError KSCrashErrorWithDomain:@"KSJSONCodecObjC"
                                           code:0
                                    description:@"Type %@ not allowed as top level container",
                        [element class]];
@@ -278,7 +278,7 @@ static int onEndContainer(void* const userData)
 
     if([codec->_containerStack count] == 0)
     {
-        codec.error = [NSError errorWithDomain:@"KSJSONCodecObjC"
+        codec.error = [NSError KSCrashErrorWithDomain:@"KSJSONCodecObjC"
                                           code:0
                                    description:@"Already at the top level; no container left to end"];
         return KSJSON_ERROR_INVALID_DATA;
@@ -318,7 +318,7 @@ static int encodeObject(KSJSONCodec* codec, id object, NSString* name, KSJSONEnc
         result = ksjson_addStringElement(context, cName, data.bytes, (int)data.length);
         if(result == KSJSON_ERROR_INVALID_CHARACTER)
         {
-            codec.error = [NSError errorWithDomain:@"KSJSONCodecObjC"
+            codec.error = [NSError KSCrashErrorWithDomain:@"KSJSONCodecObjC"
                                               code:0
                                        description:@"Invalid character in %@", object];
         }
@@ -399,7 +399,7 @@ static int encodeObject(KSJSONCodec* codec, id object, NSString* name, KSJSONEnc
         return ksjson_addDataElement(context, cName, data.bytes, (int)data.length);
     }
 
-    codec.error = [NSError errorWithDomain:@"KSJSONCodecObjC"
+    codec.error = [NSError KSCrashErrorWithDomain:@"KSJSONCodecObjC"
                                       code:0
                                description:@"Could not determine type of %@", [object class]];
     return KSJSON_ERROR_INVALID_DATA;
@@ -445,7 +445,7 @@ static int encodeObject(KSJSONCodec* codec, id object, NSString* name, KSJSONEnc
                                (__bridge void*)codec, &errorOffset);
     if(result != KSJSON_OK && codec.error == nil)
     {
-        codec.error = [NSError errorWithDomain:@"KSJSONCodecObjC"
+        codec.error = [NSError KSCrashErrorWithDomain:@"KSJSONCodecObjC"
                                           code:0
                                    description:@"%s (offset %d)",
                        ksjson_stringForError(result),

--- a/Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.h
+++ b/Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.h
@@ -1,5 +1,5 @@
 //
-//  NSError+SimpleConstructor.h
+//  NSError+KSCrashSimpleConstructor.h
 //
 //  Created by Karl Stenerud on 2013-02-09.
 //
@@ -29,7 +29,7 @@
 /**
  * Simpler interface for constructing NSError objects.
  */
-@interface NSError (SimpleConstructor)
+@interface NSError (KSCrashSimpleConstructor)
 
 /** Convenience constructor to make an error with the specified localized description.
  *
@@ -38,7 +38,7 @@
  * @param fmt Description of the error (gets placed into the user data with the key
  *                    NSLocalizedDescriptionKey).
  */
-+ (NSError*) errorWithDomain:(NSString*) domain
++ (NSError*) KSCrashErrorWithDomain:(NSString*) domain
                         code:(NSInteger) code
                  description:(NSString*) fmt, ...;
 
@@ -51,7 +51,7 @@
  *                    NSLocalizedDescriptionKey).
  * @return NO (to keep the analyzer happy).
  */
-+ (BOOL) fillError:(NSError**) error
++ (BOOL) KSCrashFillError:(NSError**) error
         withDomain:(NSString*) domain
               code:(NSInteger) code
        description:(NSString*) fmt, ...;
@@ -61,6 +61,6 @@
  * @param error Error pointer to fill (ignored if nil).
  * @return NO (to keep the analyzer happy).
  */
-+ (BOOL) clearError:(NSError**) error;
++ (BOOL) KSCrashClearError:(NSError**) error;
 
 @end

--- a/Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.m
+++ b/Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.m
@@ -1,5 +1,5 @@
 //
-//  NSError+SimpleConstructor.m
+//  NSError+KSCrashSimpleConstructor.m
 //
 //  Created by Karl Stenerud on 2013-02-09.
 //
@@ -24,12 +24,12 @@
 // THE SOFTWARE.
 //
 
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 
 
-@implementation NSError (SimpleConstructor)
+@implementation NSError (KSCrashSimpleConstructor)
 
-+ (NSError*) errorWithDomain:(NSString*) domain code:(NSInteger) code description:(NSString*) fmt, ...
++ (NSError*) KSCrashErrorWithDomain:(NSString*) domain code:(NSInteger) code description:(NSString*) fmt, ...
 {
     va_list args;
     va_start(args, fmt);
@@ -43,7 +43,7 @@
                                                                 forKey:NSLocalizedDescriptionKey]];
 }
 
-+ (BOOL) fillError:(NSError* __autoreleasing *) error
++ (BOOL) KSCrashFillError:(NSError* __autoreleasing *) error
         withDomain:(NSString*) domain
               code:(NSInteger) code
        description:(NSString*) fmt, ...
@@ -64,7 +64,7 @@
     return NO;
 }
 
-+ (BOOL) clearError:(NSError* __autoreleasing *) error
++ (BOOL) KSCrashClearError:(NSError* __autoreleasing *) error
 {
     if(error != nil)
     {

--- a/Source/KSCrash/Reporting/Filters/KSCrashReportFilterBasic.m
+++ b/Source/KSCrash/Reporting/Filters/KSCrashReportFilterBasic.m
@@ -27,7 +27,7 @@
 
 #import "KSCrashReportFilterBasic.h"
 #import "NSError+KSCrashSimpleConstructor.h"
-#import "Container+DeepSearch.h"
+#import "Container+KSCrashDeepSearch.h"
 #import "KSVarArgs.h"
 
 //#define KSLogger_LocalLevel TRACE
@@ -389,7 +389,7 @@
         id object = nil;
         if([self.key isKindOfClass:[NSString class]])
         {
-            object = [report objectForKeyPath:self.key];
+            object = [report KSCrashObjectForKeyPath:self.key];
         }
         else
         {
@@ -483,7 +483,7 @@
             {
                 [concatenated appendFormat:self.separatorFmt, key];
             }
-            id object = [report objectForKeyPath:key];
+            id object = [report KSCrashObjectForKeyPath:key];
             [concatenated appendFormat:@"%@", object];
         }
         [filteredReports addObject:concatenated];
@@ -547,7 +547,7 @@
         NSMutableDictionary* subset = [NSMutableDictionary dictionary];
         for(NSString* keyPath in self.keyPaths)
         {
-            id object = [report objectForKeyPath:keyPath];
+            id object = [report KSCrashObjectForKeyPath:keyPath];
             if(object == nil)
             {
                 kscrash_callCompletion(onCompletion, filteredReports, NO,

--- a/Source/KSCrash/Reporting/Filters/KSCrashReportFilterBasic.m
+++ b/Source/KSCrash/Reporting/Filters/KSCrashReportFilterBasic.m
@@ -26,7 +26,7 @@
 
 
 #import "KSCrashReportFilterBasic.h"
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 #import "Container+DeepSearch.h"
 #import "KSVarArgs.h"
 
@@ -145,7 +145,7 @@
     if(filterCount != [keys count])
     {
         kscrash_callCompletion(onCompletion, reports, NO,
-                                 [NSError errorWithDomain:[[self class] description]
+                                 [NSError KSCrashErrorWithDomain:[[self class] description]
                                                      code:0
                                               description:@"Key/filter mismatch (%d keys, %d filters",
                                   [keys count], filterCount]);
@@ -181,7 +181,7 @@
                                 else if(filteredReports == nil)
                                 {
                                     kscrash_callCompletion(onCompletion, filteredReports, NO,
-                                                             [NSError errorWithDomain:[[self class] description]
+                                                             [NSError KSCrashErrorWithDomain:[[self class] description]
                                                                                  code:0
                                                                           description:@"filteredReports was nil"]);
                                 }
@@ -320,7 +320,7 @@
                                 else if(filteredReports == nil)
                                 {
                                     kscrash_callCompletion(onCompletion, filteredReports, NO,
-                                                             [NSError errorWithDomain:[[self class] description]
+                                                             [NSError KSCrashErrorWithDomain:[[self class] description]
                                                                                  code:0
                                                                           description:@"filteredReports was nil"]);
                                 }
@@ -400,7 +400,7 @@
             if(!self.allowNotFound)
             {
                 kscrash_callCompletion(onCompletion, filteredReports, NO,
-                                         [NSError errorWithDomain:[[self class] description]
+                                         [NSError KSCrashErrorWithDomain:[[self class] description]
                                                              code:0
                                                       description:@"Key not found: %@", self.key]);
                 return;
@@ -551,7 +551,7 @@
             if(object == nil)
             {
                 kscrash_callCompletion(onCompletion, filteredReports, NO,
-                                         [NSError errorWithDomain:[[self class] description]
+                                         [NSError KSCrashErrorWithDomain:[[self class] description]
                                                              code:0
                                                       description:@"Report did not have key path %@", keyPath]);
                 return;
@@ -606,7 +606,7 @@
         if(converted == nil)
         {
             kscrash_callCompletion(onCompletion, filteredReports, NO,
-                                     [NSError errorWithDomain:[[self class] description]
+                                     [NSError KSCrashErrorWithDomain:[[self class] description]
                                                          code:0
                                                   description:@"Could not convert report to UTF-8"]);
             return;

--- a/Source/KSCrash/Reporting/Filters/KSCrashReportFilterGZip.m
+++ b/Source/KSCrash/Reporting/Filters/KSCrashReportFilterGZip.m
@@ -26,7 +26,7 @@
 
 
 #import "KSCrashReportFilterGZip.h"
-#import "NSData+GZip.h"
+#import "NSData+KSCrashGZip.h"
 
 
 @interface KSCrashReportFilterGZipCompress ()
@@ -60,7 +60,7 @@
     for(NSData* report in reports)
     {
         NSError* error = nil;
-        NSData* compressedData = [report gzippedWithCompressionLevel:self.compressionLevel
+        NSData* compressedData = [report KSCrashGzippedWithCompressionLevel:self.compressionLevel
                                                                error:&error];
         if(compressedData == nil)
         {
@@ -93,7 +93,7 @@
     for(NSData* report in reports)
     {
         NSError* error = nil;
-        NSData* decompressedData = [report gunzippedWithError:&error];
+        NSData* decompressedData = [report KSCrashGunzippedWithError:&error];
         if(decompressedData == nil)
         {
             kscrash_callCompletion(onCompletion, filteredReports, NO, error);

--- a/Source/KSCrash/Reporting/Filters/Tools/Container+KSCrashDeepSearch.h
+++ b/Source/KSCrash/Reporting/Filters/Tools/Container+KSCrashDeepSearch.h
@@ -1,5 +1,5 @@
 //
-//  Container+DeepSearch
+//  Container+KSCrashDeepSearch
 //
 //  Created by Karl Stenerud on 2012-08-25.
 //
@@ -34,8 +34,8 @@
  * key series is passed as a serialized path, similar to filesystem paths
  * (a string where entries are separated by slashes).
  *
- * For example, if objectForDeepKey were called with [@"top", @"sublevel", @"2",
- * @"item] (or objectForKeyPath were called with @"top/sublevel/2/item"), it
+ * For example, if KSCrashObjectForDeepKey were called with [@"top", @"sublevel", @"2",
+ * @"item] (or KSCrashObjectForKeyPath were called with @"top/sublevel/2/item"), it
  * would search as follows:
  *
  *    result = [self objectForKey:@"top"];
@@ -60,7 +60,7 @@
 /**
  * Deep key search methods for NSDictionary.
  */
-@interface NSDictionary (DeepSearch)
+@interface NSDictionary (KSCrashDeepSearch)
 
 #pragma mark - Lookups
 
@@ -71,7 +71,7 @@
  *
  * @param deepKey A set of keys to drill down with.
  */
-- (id) objectForDeepKey:(NSArray*) deepKey;
+- (id) KSCrashObjectForDeepKey:(NSArray*) deepKey;
 
 
 /** Do a deep search using the specified keys.
@@ -81,7 +81,7 @@
  *
  * @param keyPath A full key path, separated by slash (e.g. @"a/b/c")
  */
-- (id) objectForKeyPath:(NSString*) keyPath;
+- (id) KSCrashObjectForKeyPath:(NSString*) keyPath;
 
 
 #pragma mark - Mutators
@@ -95,7 +95,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void) setObject:(id) anObject forDeepKey:(NSArray*) deepKey;
+- (void) KSCrashSetObject:(id) anObject forDeepKey:(NSArray*) deepKey;
 
 /** Set an associated object at the specified key path.
  *
@@ -106,7 +106,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void) setObject:(id) anObject forKeyPath:(NSString*) keyPath;
+- (void) KSCrashSetObject:(id) anObject forKeyPath:(NSString*) keyPath;
 
 /** Remove an associated object at the specified deep key.
  *
@@ -117,7 +117,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void) removeObjectForDeepKey:(NSArray*) deepKey;
+- (void) KSCrashRemoveObjectForDeepKey:(NSArray*) deepKey;
 
 /** Remove an associated object at the specified key path.
  *
@@ -128,7 +128,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void) removeObjectForKeyPath:(NSString*) keyPath;
+- (void) KSCrashRemoveObjectForKeyPath:(NSString*) keyPath;
 
 @end
 
@@ -138,7 +138,7 @@
 /**
  * Deep key search methods for NSDictionary.
  */
-@interface NSArray (DeepSearch)
+@interface NSArray (KSCrashDeepSearch)
 
 #pragma mark - Lookups
 
@@ -149,7 +149,7 @@
  *
  * @param deepKey A set of keys to drill down with.
  */
-- (id) objectForDeepKey:(NSArray*) deepKey;
+- (id) KSCrashObjectForDeepKey:(NSArray*) deepKey;
 
 
 /** Do a deep search using the specified keys.
@@ -159,7 +159,7 @@
  *
  * @param keyPath A full key path, separated by slash (e.g. @"a/b/c")
  */
-- (id) objectForKeyPath:(NSString*) keyPath;
+- (id) KSCrashObjectForKeyPath:(NSString*) keyPath;
 
 
 #pragma mark - Mutators
@@ -173,7 +173,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void) setObject:(id) anObject forDeepKey:(NSArray*) deepKey;
+- (void) KSCrashSetObject:(id) anObject forDeepKey:(NSArray*) deepKey;
 
 /** Set an associated object at the specified key path.
  *
@@ -184,7 +184,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void) setObject:(id) anObject forKeyPath:(NSString*) keyPath;
+- (void) KSCrashSetObject:(id) anObject forKeyPath:(NSString*) keyPath;
 
 /** Remove an associated object at the specified deep key.
  *
@@ -195,7 +195,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void) removeObjectForDeepKey:(NSArray*) deepKey;
+- (void) KSCrashRemoveObjectForDeepKey:(NSArray*) deepKey;
 
 /** Remove an associated object at the specified key path.
  *
@@ -206,6 +206,6 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void) removeObjectForKeyPath:(NSString*) keyPath;
+- (void) KSCrashRemoveObjectForKeyPath:(NSString*) keyPath;
 
 @end

--- a/Source/KSCrash/Reporting/Filters/Tools/Container+KSCrashDeepSearch.m
+++ b/Source/KSCrash/Reporting/Filters/Tools/Container+KSCrashDeepSearch.m
@@ -1,5 +1,5 @@
 //
-//  Container+DeepSearch
+//  Container+KSCrashDeepSearch
 //
 //  Created by Karl Stenerud on 2012-08-25.
 //
@@ -25,7 +25,7 @@
 //
 
 
-#import "Container+DeepSearch.h"
+#import "Container+KSCrashDeepSearch.h"
 
 
 #pragma mark - Base functionality
@@ -193,34 +193,34 @@ static void removeObjectForKeyPath(id container, NSString* keyPath)
 
 #pragma mark - NSDictionary Category
 
-@implementation NSDictionary (DeepSearch)
+@implementation NSDictionary (KSCrashDeepSearch)
 
-- (id) objectForDeepKey:(NSArray*) deepKey
+- (id) KSCrashObjectForDeepKey:(NSArray*) deepKey
 {
     return objectForDeepKey(self, deepKey);
 }
 
-- (id) objectForKeyPath:(NSString*) keyPath
+- (id) KSCrashObjectForKeyPath:(NSString*) keyPath
 {
     return objectForKeyPath(self, keyPath);
 }
 
-- (void) setObject:(id) anObject forDeepKey:(NSArray*) deepKey
+- (void) KSCrashSetObject:(id) anObject forDeepKey:(NSArray*) deepKey
 {
     setObjectForDeepKey(self, anObject, deepKey);
 }
 
-- (void) setObject:(id) anObject forKeyPath:(NSString*) keyPath
+- (void) KSCrashSetObject:(id) anObject forKeyPath:(NSString*) keyPath
 {
     setObjectForKeyPath(self, anObject, keyPath);
 }
 
-- (void) removeObjectForDeepKey:(NSArray*) deepKey
+- (void) KSCrashRemoveObjectForDeepKey:(NSArray*) deepKey
 {
     removeObjectForDeepKey(self, deepKey);
 }
 
-- (void) removeObjectForKeyPath:(NSString*) keyPath
+- (void) KSCrashRemoveObjectForKeyPath:(NSString*) keyPath
 {
     removeObjectForKeyPath(self, keyPath);
 }
@@ -230,34 +230,34 @@ static void removeObjectForKeyPath(id container, NSString* keyPath)
 
 #pragma mark - NSArray Category
 
-@implementation NSArray (DeepSearch)
+@implementation NSArray (KSCrashDeepSearch)
 
-- (id) objectForDeepKey:(NSArray*) deepKey
+- (id) KSCrashObjectForDeepKey:(NSArray*) deepKey
 {
     return objectForDeepKey(self, deepKey);
 }
 
-- (id) objectForKeyPath:(NSString*) keyPath
+- (id) KSCrashObjectForKeyPath:(NSString*) keyPath
 {
     return objectForKeyPath(self, keyPath);
 }
 
-- (void) setObject:(id) anObject forDeepKey:(NSArray*) deepKey
+- (void) KSCrashSetObject:(id) anObject forDeepKey:(NSArray*) deepKey
 {
     setObjectForDeepKey(self, anObject, deepKey);
 }
 
-- (void) setObject:(id) anObject forKeyPath:(NSString*) keyPath
+- (void) KSCrashSetObject:(id) anObject forKeyPath:(NSString*) keyPath
 {
     setObjectForKeyPath(self, anObject, keyPath);
 }
 
-- (void) removeObjectForDeepKey:(NSArray*) deepKey
+- (void) KSCrashRemoveObjectForDeepKey:(NSArray*) deepKey
 {
     removeObjectForDeepKey(self, deepKey);
 }
 
-- (void) removeObjectForKeyPath:(NSString*) keyPath
+- (void) KSCrashRemoveObjectForKeyPath:(NSString*) keyPath
 {
     removeObjectForKeyPath(self, keyPath);
 }

--- a/Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.m
+++ b/Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.m
@@ -27,7 +27,7 @@
 
 #import "NSData+GZip.h"
 
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 #import <zlib.h>
 
 
@@ -68,7 +68,7 @@ static NSString* zlibError(int errorCode)
     uInt length = (uInt)[self length];
     if(length == 0)
     {
-        [NSError clearError:error];
+        [NSError KSCrashClearError:error];
         return [NSData data];
     }
 
@@ -86,7 +86,7 @@ static NSString* zlibError(int errorCode)
                        Z_DEFAULT_STRATEGY);
     if(err != Z_OK)
     {
-        [NSError fillError:error
+        [NSError KSCrashFillError:error
                 withDomain:[[self class] description]
                       code:0
                description:@"deflateInit2: %@", zlibError(err)];
@@ -106,7 +106,7 @@ static NSString* zlibError(int errorCode)
 
     if(err != Z_STREAM_END)
     {
-        [NSError fillError:error
+        [NSError KSCrashFillError:error
                 withDomain:[[self class] description]
                       code:0
                description:@"deflate: %@", zlibError(err)];
@@ -116,7 +116,7 @@ static NSString* zlibError(int errorCode)
 
     [compressedData setLength:stream.total_out];
 
-    [NSError clearError:error];
+    [NSError KSCrashClearError:error];
     deflateEnd(&stream);
     return compressedData;
 }
@@ -126,7 +126,7 @@ static NSString* zlibError(int errorCode)
     uInt length = (uInt)[self length];
     if(length == 0)
     {
-        [NSError clearError:error];
+        [NSError KSCrashClearError:error];
         return [NSData data];
     }
 
@@ -139,7 +139,7 @@ static NSString* zlibError(int errorCode)
     err = inflateInit2(&stream, 16+MAX_WBITS);
     if(err != Z_OK)
     {
-        [NSError fillError:error
+        [NSError KSCrashFillError:error
                 withDomain:[[self class] description]
                       code:0
                description:@"inflateInit2: %@", zlibError(err)];
@@ -157,7 +157,7 @@ static NSString* zlibError(int errorCode)
         err = inflate(&stream, Z_NO_FLUSH);
         if(err != Z_OK && err != Z_STREAM_END)
         {
-            [NSError fillError:error
+            [NSError KSCrashFillError:error
                     withDomain:[[self class] description]
                           code:0
                    description:@"inflate: %@", zlibError(err)];
@@ -168,7 +168,7 @@ static NSString* zlibError(int errorCode)
                            length:sizeof(buffer) - stream.avail_out];
     }
 
-    [NSError clearError:error];
+    [NSError KSCrashClearError:error];
     inflateEnd(&stream);
     return expandedData;
 }

--- a/Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.h
+++ b/Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.h
@@ -1,5 +1,5 @@
 //
-//  NSData+GZip.h
+//  NSData+KSCrashGZip.h
 //
 //  Created by Karl Stenerud on 2012-02-19.
 //
@@ -31,7 +31,7 @@
 /**
  * GNU zip/unzip support for NSData.
  */
-@interface NSData (GZip)
+@interface NSData (KSCrashGZip)
 
 /**
  * Gzip the data in this object (no header).
@@ -47,7 +47,7 @@
  *
  * @return A new NSData with the gzipped contents of this object.
  */
-- (NSData*) gzippedWithCompressionLevel:(int) compressionLevel
+- (NSData*) KSCrashGzippedWithCompressionLevel:(int) compressionLevel
                                   error:(NSError**) error;
 
 /**
@@ -58,6 +58,6 @@
  *
  * @return A new NSData with the gunzipped contents of this object.
  */
-- (NSData*) gunzippedWithError:(NSError**) error;
+- (NSData*) KSCrashGunzippedWithError:(NSError**) error;
 
 @end

--- a/Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.m
+++ b/Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.m
@@ -1,5 +1,5 @@
 //
-//  NSData+GZip.m
+//  NSData+KSCrashGZip.m
 //
 //  Created by Karl Stenerud on 2012-02-19.
 //
@@ -25,7 +25,7 @@
 //
 
 
-#import "NSData+GZip.h"
+#import "NSData+KSCrashGZip.h"
 
 #import "NSError+KSCrashSimpleConstructor.h"
 #import <zlib.h>
@@ -60,9 +60,9 @@ static NSString* zlibError(int errorCode)
     return [NSString stringWithFormat:@"Unknown error: %d", errorCode];
 }
 
-@implementation NSData (GZip)
+@implementation NSData (KSCrashGZip)
 
-- (NSData*) gzippedWithCompressionLevel:(int) compressionLevel
+- (NSData*) KSCrashGzippedWithCompressionLevel:(int) compressionLevel
                                   error:(NSError* __autoreleasing *) error
 {
     uInt length = (uInt)[self length];
@@ -121,7 +121,7 @@ static NSString* zlibError(int errorCode)
     return compressedData;
 }
 
-- (NSData*) gunzippedWithError:(NSError* __autoreleasing *) error
+- (NSData*) KSCrashGunzippedWithError:(NSError* __autoreleasing *) error
 {
     uInt length = (uInt)[self length];
     if(length == 0)

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkEMail.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkEMail.m
@@ -292,7 +292,7 @@
 
 #else
 
-#import "NSData+GZip.h"
+#import "NSData+KSCrashGZip.h"
 
 @implementation KSCrashReportSinkEMail
 
@@ -320,7 +320,7 @@
 {
     for(NSData* reportData in reports)
     {
-        NSString* report = [[NSString alloc] initWithData:[reportData gunzippedWithError:nil] encoding:NSUTF8StringEncoding];
+        NSString* report = [[NSString alloc] initWithData:[reportData KSCrashGunzippedWithError:nil] encoding:NSUTF8StringEncoding];
         NSLog(@"Report\n%@", report);
     }
     kscrash_callCompletion(onCompletion, reports, NO,

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkEMail.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkEMail.m
@@ -31,7 +31,7 @@
 #import "KSCrashReportFilterBasic.h"
 #import "KSCrashReportFilterGZip.h"
 #import "KSCrashReportFilterJSON.h"
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 #import "KSSystemCapabilities.h"
 
 //#define KSLogger_LocalLevel TRACE
@@ -115,7 +115,7 @@
             break;
         case MFMailComposeResultCancelled:
             kscrash_callCompletion(self.onCompletion, self.reports, NO,
-                                     [NSError errorWithDomain:[[self class] description]
+                                     [NSError KSCrashErrorWithDomain:[[self class] description]
                                                          code:0
                                                   description:@"User cancelled"]);
             break;
@@ -125,7 +125,7 @@
         default:
         {
             kscrash_callCompletion(self.onCompletion, self.reports, NO,
-                                     [NSError errorWithDomain:[[self class] description]
+                                     [NSError KSCrashErrorWithDomain:[[self class] description]
                                                          code:0
                                                   description:@"Unknown MFMailComposeResult: %d", result]);
         }
@@ -254,7 +254,7 @@
                           otherButtonTitles:nil] show];
 
         kscrash_callCompletion(onCompletion, reports, NO,
-                                 [NSError errorWithDomain:[[self class] description]
+                                 [NSError KSCrashErrorWithDomain:[[self class] description]
                                                      code:0
                                               description:@"E-Mail not enabled on device"]);
         return;
@@ -324,7 +324,7 @@
         NSLog(@"Report\n%@", report);
     }
     kscrash_callCompletion(onCompletion, reports, NO,
-                             [NSError errorWithDomain:[[self class] description]
+                             [NSError KSCrashErrorWithDomain:[[self class] description]
                                                  code:0
                                           description:@"Cannot send mail on this platform"]);
 }

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m
@@ -39,7 +39,7 @@
 #import "NSError+KSCrashSimpleConstructor.h"
 #import <mach/machine.h>
 #import "KSCrashMonitor_System.h"
-#import "NSString+URLEncode.h"
+#import "NSString+KSCrashURLEncode.h"
 
 //#define KSLogger_LocalLevel TRACE
 #import "KSLogger.h"
@@ -527,7 +527,7 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys
 - (NSURL*) urlWithAppIdentifier:(NSString*) appIdentifier
 {
     NSString* urlString = [NSString stringWithFormat:@"https://sdk.hockeyapp.net/api/2/apps/%@/crashes",
-                           [appIdentifier URLEncoded]];
+                           [appIdentifier KSCrashURLEncoded]];
     return [NSURL URLWithString:urlString];
 }
 

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m
@@ -35,7 +35,7 @@
 #import "KSCrashReportFilterBasic.h"
 #import "KSJSONCodecObjC.h"
 #import "KSReachabilityKSCrash.h"
-#import "Container+DeepSearch.h"
+#import "Container+KSCrashDeepSearch.h"
 #import "NSError+KSCrashSimpleConstructor.h"
 #import <mach/machine.h>
 #import "KSCrashMonitor_System.h"
@@ -137,7 +137,7 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys
     {
         NSString* stringValue = nil;
         NSString* key = [keys objectAtIndex:i];
-        id value = [report objectForKeyPath:key];
+        id value = [report KSCrashObjectForKeyPath:key];
         if([value isKindOfClass:[NSString class]])
         {
             stringValue = value;
@@ -318,9 +318,9 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys
     NSDictionary* report = [reportTuple objectForKey:kFilterKeyStandard];
     NSString* appleReport = [reportTuple objectForKey:kFilterKeyApple];
     NSDictionary* systemDict = [report objectForKey:@KSCrashField_System];
-    NSString* userID = self.userIDKey == nil ? nil : [self blankForNil:[report objectForKeyPath:self.userIDKey]];
-    NSString* userName = self.userNameKey == nil ? nil : [self blankForNil:[report objectForKeyPath:self.userNameKey]];
-    NSString* contactEmail = self.contactEmailKey == nil ? nil : [self blankForNil:[report objectForKeyPath:self.contactEmailKey]];
+    NSString* userID = self.userIDKey == nil ? nil : [self blankForNil:[report KSCrashObjectForKeyPath:self.userIDKey]];
+    NSString* userName = self.userNameKey == nil ? nil : [self blankForNil:[report KSCrashObjectForKeyPath:self.userNameKey]];
+    NSString* contactEmail = self.contactEmailKey == nil ? nil : [self blankForNil:[report KSCrashObjectForKeyPath:self.contactEmailKey]];
     NSString* crashReportDescription = [self.crashDescriptionKeys count] == 0 ? nil : [self descriptionForReport:report keys:self.crashDescriptionKeys];
     NSString* uuids = [self uuidsFromReport:report];
     NSDictionary* reportInfo = [report objectForKey:@KSCrashField_Report];

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m
@@ -36,7 +36,7 @@
 #import "KSJSONCodecObjC.h"
 #import "KSReachabilityKSCrash.h"
 #import "Container+DeepSearch.h"
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 #import <mach/machine.h>
 #import "KSCrashMonitor_System.h"
 #import "NSString+URLEncode.h"
@@ -385,7 +385,7 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys
     {
         if(onCompletion != nil)
         {
-            onCompletion(reports, NO, [NSError errorWithDomain:[[self class] description]
+            onCompletion(reports, NO, [NSError KSCrashErrorWithDomain:[[self class] description]
                                                           code:0
                                                    description:@"url was nil"]);
         }
@@ -426,7 +426,7 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys
              KSLOG_DEBUG(@"Post failed. Code %d", response.statusCode);
              KSLOG_TRACE(@"Response text:\n%@", text);
              kscrash_callCompletion(onCompletion, reports, NO,
-                                      [NSError errorWithDomain:[[self class] description]
+                                      [NSError KSCrashErrorWithDomain:[[self class] description]
                                                           code:response.statusCode
                                                    description:text]);
          } onError:^(NSError* error)
@@ -510,7 +510,7 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys
     {
         if(onCompletion != nil)
         {
-            onCompletion(reports, NO, [NSError errorWithDomain:[[self class] description]
+            onCompletion(reports, NO, [NSError KSCrashErrorWithDomain:[[self class] description]
                                                           code:0
                                                    description:@"appIdentifier was nil"]);
         }

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m
@@ -30,7 +30,7 @@
 #import "KSCrashReportFields.h"
 #import "KSHTTPMultipartPostBody.h"
 #import "KSHTTPRequestSender.h"
-#import "NSData+GZip.h"
+#import "NSData+KSCrashGZip.h"
 #import "KSCrashReportFilterAppleFmt.h"
 #import "KSCrashReportFilterBasic.h"
 #import "KSJSONCodecObjC.h"

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkStandard.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkStandard.m
@@ -32,7 +32,7 @@
 #import "NSData+GZip.h"
 #import "KSJSONCodecObjC.h"
 #import "KSReachabilityKSCrash.h"
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 
 //#define KSLogger_LocalLevel TRACE
 #import "KSLogger.h"

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkStandard.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkStandard.m
@@ -29,7 +29,7 @@
 
 #import "KSHTTPMultipartPostBody.h"
 #import "KSHTTPRequestSender.h"
-#import "NSData+GZip.h"
+#import "NSData+KSCrashGZip.h"
 #import "KSJSONCodecObjC.h"
 #import "KSReachabilityKSCrash.h"
 #import "NSError+KSCrashSimpleConstructor.h"

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkVictory.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkVictory.m
@@ -36,7 +36,7 @@
 #import "NSData+GZip.h"
 #import "KSJSONCodecObjC.h"
 #import "KSReachabilityKSCrash.h"
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 #import "KSSystemCapabilities.h"
 
 //#define KSLogger_LocalLevel TRACE
@@ -153,7 +153,7 @@
          {
              NSString* text = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
              kscrash_callCompletion(onCompletion, reports, NO,
-                                      [NSError errorWithDomain:[[self class] description]
+                                      [NSError KSCrashErrorWithDomain:[[self class] description]
                                                           code:response.statusCode
                                                    description:text]);
          } onError:^(NSError* error2)

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkVictory.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkVictory.m
@@ -33,7 +33,7 @@
 
 #import "KSHTTPMultipartPostBody.h"
 #import "KSHTTPRequestSender.h"
-#import "NSData+GZip.h"
+#import "NSData+KSCrashGZip.h"
 #import "KSJSONCodecObjC.h"
 #import "KSReachabilityKSCrash.h"
 #import "NSError+KSCrashSimpleConstructor.h"
@@ -136,7 +136,7 @@
     // Content-Type: multipart/form-data; boundary=xxx
     // Content-Encoding: gzip
     request.HTTPMethod = @"POST";
-    request.HTTPBody = [[body data] gzippedWithCompressionLevel:-1 error:nil];
+    request.HTTPBody = [[body data] KSCrashGzippedWithCompressionLevel:-1 error:nil];
     [request setValue:body.contentType forHTTPHeaderField:@"Content-Type"];
     [request setValue:@"gzip" forHTTPHeaderField:@"Content-Encoding"];
     [request setValue:@"KSCrashReporter" forHTTPHeaderField:@"User-Agent"];

--- a/Source/KSCrash/Reporting/Tools/KSHTTPMultipartPostBody.m
+++ b/Source/KSCrash/Reporting/Tools/KSHTTPMultipartPostBody.m
@@ -28,7 +28,7 @@
 #import "KSHTTPMultipartPostBody.h"
 
 #import "NSMutableData+AppendUTF8.h"
-#import "NSString+URLEncode.h"
+#import "NSString+KSCrashURLEncode.h"
 
 
 /**

--- a/Source/KSCrash/Reporting/Tools/KSHTTPMultipartPostBody.m
+++ b/Source/KSCrash/Reporting/Tools/KSHTTPMultipartPostBody.m
@@ -27,7 +27,7 @@
 
 #import "KSHTTPMultipartPostBody.h"
 
-#import "NSMutableData+AppendUTF8.h"
+#import "NSMutableData+KSCrashAppendUTF8.h"
 #import "NSString+KSCrashURLEncode.h"
 
 
@@ -172,30 +172,30 @@
     for(KSHTTPPostField* field in _fields)
     {
         if (firstFieldSent) {
-            [data appendUTF8String:@"\r\n"];
+            [data KSCrashAppendUTF8String:@"\r\n"];
         } else {
             firstFieldSent = YES;
         }
-        [data appendUTF8Format:@"--%@\r\n", _boundary];
+        [data KSCrashAppendUTF8Format:@"--%@\r\n", _boundary];
         if(field.filename != nil)
         {
-            [data appendUTF8Format:@"Content-Disposition: form-data; name=\"%@\"; filename=\"%@\"\r\n",
+            [data KSCrashAppendUTF8Format:@"Content-Disposition: form-data; name=\"%@\"; filename=\"%@\"\r\n",
              [self toStringWithQuotesEscaped:field.name],
              [self toStringWithQuotesEscaped:field.filename]];
         }
         else
         {
-            [data appendUTF8Format:@"Content-Disposition: form-data; name=\"%@\"\r\n",
+            [data KSCrashAppendUTF8Format:@"Content-Disposition: form-data; name=\"%@\"\r\n",
              [self toStringWithQuotesEscaped:field.name]];
         }
         if(field.contentType != nil)
         {
-            [data appendUTF8Format:@"Content-Type: %@\r\n", field.contentType];
+            [data KSCrashAppendUTF8Format:@"Content-Type: %@\r\n", field.contentType];
         }
-        [data appendUTF8Format:@"\r\n", _boundary];
+        [data KSCrashAppendUTF8Format:@"\r\n", _boundary];
         [data appendData:field.data];
     }
-    [data appendUTF8Format:@"\r\n--%@--\r\n", _boundary];
+    [data KSCrashAppendUTF8Format:@"\r\n--%@--\r\n", _boundary];
     
     return data;
 }

--- a/Source/KSCrash/Reporting/Tools/KSHTTPRequestSender.m
+++ b/Source/KSCrash/Reporting/Tools/KSHTTPRequestSender.m
@@ -26,7 +26,7 @@
 
 
 #import "KSHTTPRequestSender.h"
-#import "NSError+SimpleConstructor.h"
+#import "NSError+KSCrashSimpleConstructor.h"
 
 
 @implementation KSHTTPRequestSender
@@ -47,14 +47,14 @@
     {
         if(response == nil)
         {
-            error = [NSError errorWithDomain:[[self class] description]
+            error = [NSError KSCrashErrorWithDomain:[[self class] description]
                                         code:0
                                  description:@"Response was nil"];
         }
         
         if(![response isKindOfClass:[NSHTTPURLResponse class]])
         {
-            error = [NSError errorWithDomain:[[self class] description]
+            error = [NSError KSCrashErrorWithDomain:[[self class] description]
                                         code:0
                                  description:@"Response was of type %@. Expected NSHTTPURLResponse",
                      [response class]];

--- a/Source/KSCrash/Reporting/Tools/NSMutableData+KSCrashAppendUTF8.h
+++ b/Source/KSCrash/Reporting/Tools/NSMutableData+KSCrashAppendUTF8.h
@@ -1,5 +1,5 @@
 //
-//  NSMutableData+AppendUTF8.m
+//  NSMutableData+KSCrashAppendUTF8.h
 //
 //  Created by Karl Stenerud on 2012-02-26.
 //
@@ -25,27 +25,23 @@
 //
 
 
-#import "NSMutableData+AppendUTF8.h"
+#import <Foundation/Foundation.h>
 
 
-@implementation NSMutableData (AppendUTF8)
+/** Encodes strings to UTF-8 format.
+ */
+@interface NSMutableData (KSCrashAppendUTF8)
 
-- (void) appendUTF8String:(NSString*) string
-{
-    const char* cstring = [string UTF8String];
-    [self appendBytes:cstring length:strlen(cstring)];
-}
+/** Append a string encoded as UTF-8.
+ *
+ * @param format Printf-stype format.
+ */
+- (void) KSCrashAppendUTF8Format:(NSString*) format, ...;
 
-- (void) appendUTF8Format:(NSString*) format, ...
-{
-    va_list args;
-    va_start(args, format);
-    NSString* string = [[NSString alloc] initWithFormat:format arguments:args];
-    va_end(args);
-    const char* cstring = [string UTF8String];
-    [self appendBytes:cstring length:strlen(cstring)];
-}
+/** Append a string encoded as UTF-8.
+ *
+ * @param string The string to append.
+ */
+- (void) KSCrashAppendUTF8String:(NSString*) string;
 
 @end
-
-@interface NSMutableData_AppendUTF8_GHO92D : NSObject @end @implementation NSMutableData_AppendUTF8_GHO92D @end

--- a/Source/KSCrash/Reporting/Tools/NSMutableData+KSCrashAppendUTF8.m
+++ b/Source/KSCrash/Reporting/Tools/NSMutableData+KSCrashAppendUTF8.m
@@ -1,5 +1,5 @@
 //
-//  NSMutableData+AppendUTF8.h
+//  NSMutableData+KSCrashAppendUTF8.m
 //
 //  Created by Karl Stenerud on 2012-02-26.
 //
@@ -25,23 +25,27 @@
 //
 
 
-#import <Foundation/Foundation.h>
+#import "NSMutableData+KSCrashAppendUTF8.h"
 
 
-/** Encodes strings to UTF-8 format.
- */
-@interface NSMutableData (AppendUTF8)
+@implementation NSMutableData (KSCrashAppendUTF8)
 
-/** Append a string encoded as UTF-8.
- *
- * @param format Printf-stype format.
- */
-- (void) appendUTF8Format:(NSString*) format, ...;
+- (void) KSCrashAppendUTF8String:(NSString*) string
+{
+    const char* cstring = [string UTF8String];
+    [self appendBytes:cstring length:strlen(cstring)];
+}
 
-/** Append a string encoded as UTF-8.
- *
- * @param string The string to append.
- */
-- (void) appendUTF8String:(NSString*) string;
+- (void) KSCrashAppendUTF8Format:(NSString*) format, ...
+{
+    va_list args;
+    va_start(args, format);
+    NSString* string = [[NSString alloc] initWithFormat:format arguments:args];
+    va_end(args);
+    const char* cstring = [string UTF8String];
+    [self appendBytes:cstring length:strlen(cstring)];
+}
 
 @end
+
+@interface NSMutableData_AppendUTF8_GHO92D : NSObject @end @implementation NSMutableData_AppendUTF8_GHO92D @end

--- a/Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.h
+++ b/Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.h
@@ -1,5 +1,5 @@
 //
-//  NSString+URLEncode.h
+//  NSString+KSCrashURLEncode.h
 //
 //  Created by karl on 2016-04-11.
 //
@@ -26,8 +26,8 @@
 
 #import <Foundation/Foundation.h>
 
-@interface NSString (URLEncode)
+@interface NSString (KSCrashURLEncode)
 
-- (NSString*) URLEncoded;
+- (NSString*) KSCrashURLEncoded;
 
 @end

--- a/Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.m
+++ b/Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.m
@@ -1,5 +1,5 @@
 //
-//  NSString+URLEncode.m
+//  NSString+KSCrashURLEncode.m
 //
 //  Created by karl on 2016-04-11.
 //
@@ -24,11 +24,11 @@
 // THE SOFTWARE.
 //
 
-#import "NSString+URLEncode.h"
+#import "NSString+KSCrashURLEncode.h"
 
-@implementation NSString (URLEncode)
+@implementation NSString (KSCrashURLEncode)
 
-- (NSString*) URLEncoded
+- (NSString*) KSCrashURLEncoded
 {
 #if __IPHONE_OS_VERSION_MAX_ALLOWED < 70000
     return [self stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];

--- a/TVOS/KSCrash-TVOS.xcodeproj/project.pbxproj
+++ b/TVOS/KSCrash-TVOS.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		8A25074D1DA876C300D7F158 /* KSSystemInfo_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2507271DA876C300D7F158 /* KSSystemInfo_Tests.m */; };
 		8A25074F1DA876C300D7F158 /* NSData+Gzip_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2507291DA876C300D7F158 /* NSData+Gzip_Tests.m */; };
 		8A2507511DA876C300D7F158 /* NSError+KSCrashSimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A25072B1DA876C300D7F158 /* NSError+KSCrashSimpleConstructor_Tests.m */; };
-		8A2507521DA876C300D7F158 /* NSMutableData+AppendUTF8_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A25072C1DA876C300D7F158 /* NSMutableData+AppendUTF8_Tests.m */; };
+		8A2507521DA876C300D7F158 /* NSMutableData+KSCrashAppendUTF8_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A25072C1DA876C300D7F158 /* NSMutableData+KSCrashAppendUTF8_Tests.m */; };
 		8A2507541DA876C300D7F158 /* XCTestCase+KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A25072F1DA876C300D7F158 /* XCTestCase+KSCrash.m */; };
 		CB1806901E0DA06E00239506 /* KSStackCursor_Backtrace.c in Sources */ = {isa = PBXBuildFile; fileRef = CB18068A1E0DA06E00239506 /* KSStackCursor_Backtrace.c */; };
 		CB1806911E0DA06E00239506 /* KSStackCursor_Backtrace.h in Headers */ = {isa = PBXBuildFile; fileRef = CB18068B1E0DA06E00239506 /* KSStackCursor_Backtrace.h */; };
@@ -200,8 +200,8 @@
 		CBEE5D6A1CB86989005EAF61 /* KSHTTPRequestSender.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CCC1CB86989005EAF61 /* KSHTTPRequestSender.m */; };
 		CBEE5D6B1CB86989005EAF61 /* KSReachabilityKSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCD1CB86989005EAF61 /* KSReachabilityKSCrash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBEE5D6C1CB86989005EAF61 /* KSReachabilityKSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CCE1CB86989005EAF61 /* KSReachabilityKSCrash.m */; };
-		CBEE5D6D1CB86989005EAF61 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCF1CB86989005EAF61 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBEE5D6E1CB86989005EAF61 /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CD01CB86989005EAF61 /* NSMutableData+AppendUTF8.m */; };
+		CBEE5D6D1CB86989005EAF61 /* NSMutableData+KSCrashAppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCF1CB86989005EAF61 /* NSMutableData+KSCrashAppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBEE5D6E1CB86989005EAF61 /* NSMutableData+KSCrashAppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CD01CB86989005EAF61 /* NSMutableData+KSCrashAppendUTF8.m */; };
 		CBEE5D6F1CB86989005EAF61 /* Demangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CD31CB86989005EAF61 /* Demangle.cpp */; };
 		CBEE5D701CB86989005EAF61 /* Demangle.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CD41CB86989005EAF61 /* Demangle.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBEE5D711CB86989005EAF61 /* DemangleNodes.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CD51CB86989005EAF61 /* DemangleNodes.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -301,7 +301,7 @@
 		F05D77512101FB4300968B97 /* KSHTTPMultipartPostBody.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CC91CB86989005EAF61 /* KSHTTPMultipartPostBody.h */; };
 		F05D77522101FB4300968B97 /* KSHTTPRequestSender.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCB1CB86989005EAF61 /* KSHTTPRequestSender.h */; };
 		F05D77532101FB4300968B97 /* KSReachabilityKSCrash.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCD1CB86989005EAF61 /* KSReachabilityKSCrash.h */; };
-		F05D77542101FB4300968B97 /* NSMutableData+AppendUTF8.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCF1CB86989005EAF61 /* NSMutableData+AppendUTF8.h */; };
+		F05D77542101FB4300968B97 /* NSMutableData+KSCrashAppendUTF8.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCF1CB86989005EAF61 /* NSMutableData+KSCrashAppendUTF8.h */; };
 		F05D77552101FB4300968B97 /* NSString+KSCrashURLEncode.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DBC1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.h */; };
 		F05D77562101FB4300968B97 /* KSCrashInstallation+Private.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C331CB86989005EAF61 /* KSCrashInstallation+Private.h */; };
 		F05D77572101FB4300968B97 /* KSCrashInstallation.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C341CB86989005EAF61 /* KSCrashInstallation.h */; };
@@ -377,7 +377,7 @@
 		F05D77F32101FBF300968B97 /* KSHTTPMultipartPostBody.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CCA1CB86989005EAF61 /* KSHTTPMultipartPostBody.m */; };
 		F05D77F52101FBF300968B97 /* KSHTTPRequestSender.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CCC1CB86989005EAF61 /* KSHTTPRequestSender.m */; };
 		F05D77F72101FBF300968B97 /* KSReachabilityKSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CCE1CB86989005EAF61 /* KSReachabilityKSCrash.m */; };
-		F05D77F92101FBF300968B97 /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CD01CB86989005EAF61 /* NSMutableData+AppendUTF8.m */; };
+		F05D77F92101FBF300968B97 /* NSMutableData+KSCrashAppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CD01CB86989005EAF61 /* NSMutableData+KSCrashAppendUTF8.m */; };
 		F05D77FB2101FBF300968B97 /* NSString+KSCrashURLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DBD1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.m */; };
 		F05D77FE2101FBF300968B97 /* KSCrashInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5C351CB86989005EAF61 /* KSCrashInstallation.m */; };
 		F05D78002101FBF300968B97 /* KSCrashInstallation+Alert.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8F1DD91CCAF43A0022CDF0 /* KSCrashInstallation+Alert.m */; };
@@ -482,7 +482,7 @@
 		F05D78AA210204CA00968B97 /* KSHTTPMultipartPostBody.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CC91CB86989005EAF61 /* KSHTTPMultipartPostBody.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D78AC210204CA00968B97 /* KSHTTPRequestSender.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCB1CB86989005EAF61 /* KSHTTPRequestSender.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D78AE210204CA00968B97 /* KSReachabilityKSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCD1CB86989005EAF61 /* KSReachabilityKSCrash.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F05D78B0210204CA00968B97 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCF1CB86989005EAF61 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F05D78B0210204CA00968B97 /* NSMutableData+KSCrashAppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCF1CB86989005EAF61 /* NSMutableData+KSCrashAppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D78B2210204CA00968B97 /* NSString+KSCrashURLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DBC1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D78C0210208FB00968B97 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F05D78BF210208FB00968B97 /* Foundation.framework */; };
 /* End PBXBuildFile section */
@@ -513,7 +513,7 @@
 				F05D77512101FB4300968B97 /* KSHTTPMultipartPostBody.h in Copy Headers */,
 				F05D77522101FB4300968B97 /* KSHTTPRequestSender.h in Copy Headers */,
 				F05D77532101FB4300968B97 /* KSReachabilityKSCrash.h in Copy Headers */,
-				F05D77542101FB4300968B97 /* NSMutableData+AppendUTF8.h in Copy Headers */,
+				F05D77542101FB4300968B97 /* NSMutableData+KSCrashAppendUTF8.h in Copy Headers */,
 				F05D77552101FB4300968B97 /* NSString+KSCrashURLEncode.h in Copy Headers */,
 				F05D77562101FB4300968B97 /* KSCrashInstallation+Private.h in Copy Headers */,
 				F05D77572101FB4300968B97 /* KSCrashInstallation.h in Copy Headers */,
@@ -641,7 +641,7 @@
 		8A2507271DA876C300D7F158 /* KSSystemInfo_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSSystemInfo_Tests.m; path = "../../Source/KSCrash-Tests/KSSystemInfo_Tests.m"; sourceTree = "<group>"; };
 		8A2507291DA876C300D7F158 /* NSData+Gzip_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+Gzip_Tests.m"; path = "../../Source/KSCrash-Tests/NSData+Gzip_Tests.m"; sourceTree = "<group>"; };
 		8A25072B1DA876C300D7F158 /* NSError+KSCrashSimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+KSCrashSimpleConstructor_Tests.m"; path = "../../Source/KSCrash-Tests/NSError+KSCrashSimpleConstructor_Tests.m"; sourceTree = "<group>"; };
-		8A25072C1DA876C300D7F158 /* NSMutableData+AppendUTF8_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+AppendUTF8_Tests.m"; path = "../../Source/KSCrash-Tests/NSMutableData+AppendUTF8_Tests.m"; sourceTree = "<group>"; };
+		8A25072C1DA876C300D7F158 /* NSMutableData+KSCrashAppendUTF8_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+KSCrashAppendUTF8_Tests.m"; path = "../../Source/KSCrash-Tests/NSMutableData+KSCrashAppendUTF8_Tests.m"; sourceTree = "<group>"; };
 		8A25072E1DA876C300D7F158 /* XCTestCase+KSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+KSCrash.h"; path = "../../Source/KSCrash-Tests/XCTestCase+KSCrash.h"; sourceTree = "<group>"; };
 		8A25072F1DA876C300D7F158 /* XCTestCase+KSCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+KSCrash.m"; path = "../../Source/KSCrash-Tests/XCTestCase+KSCrash.m"; sourceTree = "<group>"; };
 		CB18068A1E0DA06E00239506 /* KSStackCursor_Backtrace.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = KSStackCursor_Backtrace.c; sourceTree = "<group>"; };
@@ -805,8 +805,8 @@
 		CBEE5CCC1CB86989005EAF61 /* KSHTTPRequestSender.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSHTTPRequestSender.m; sourceTree = "<group>"; };
 		CBEE5CCD1CB86989005EAF61 /* KSReachabilityKSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSReachabilityKSCrash.h; sourceTree = "<group>"; };
 		CBEE5CCE1CB86989005EAF61 /* KSReachabilityKSCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSReachabilityKSCrash.m; sourceTree = "<group>"; };
-		CBEE5CCF1CB86989005EAF61 /* NSMutableData+AppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableData+AppendUTF8.h"; sourceTree = "<group>"; };
-		CBEE5CD01CB86989005EAF61 /* NSMutableData+AppendUTF8.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableData+AppendUTF8.m"; sourceTree = "<group>"; };
+		CBEE5CCF1CB86989005EAF61 /* NSMutableData+KSCrashAppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableData+KSCrashAppendUTF8.h"; sourceTree = "<group>"; };
+		CBEE5CD01CB86989005EAF61 /* NSMutableData+KSCrashAppendUTF8.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableData+KSCrashAppendUTF8.m"; sourceTree = "<group>"; };
 		CBEE5CD31CB86989005EAF61 /* Demangle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Demangle.cpp; sourceTree = "<group>"; };
 		CBEE5CD41CB86989005EAF61 /* Demangle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Demangle.h; sourceTree = "<group>"; };
 		CBEE5CD51CB86989005EAF61 /* DemangleNodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DemangleNodes.h; sourceTree = "<group>"; };
@@ -888,7 +888,7 @@
 				8A2507271DA876C300D7F158 /* KSSystemInfo_Tests.m */,
 				8A2507291DA876C300D7F158 /* NSData+Gzip_Tests.m */,
 				8A25072B1DA876C300D7F158 /* NSError+KSCrashSimpleConstructor_Tests.m */,
-				8A25072C1DA876C300D7F158 /* NSMutableData+AppendUTF8_Tests.m */,
+				8A25072C1DA876C300D7F158 /* NSMutableData+KSCrashAppendUTF8_Tests.m */,
 				8A25072E1DA876C300D7F158 /* XCTestCase+KSCrash.h */,
 				8A25072F1DA876C300D7F158 /* XCTestCase+KSCrash.m */,
 				8A2507021DA8768E00D7F158 /* Info.plist */,
@@ -1189,8 +1189,8 @@
 				CBEE5CCC1CB86989005EAF61 /* KSHTTPRequestSender.m */,
 				CBEE5CCD1CB86989005EAF61 /* KSReachabilityKSCrash.h */,
 				CBEE5CCE1CB86989005EAF61 /* KSReachabilityKSCrash.m */,
-				CBEE5CCF1CB86989005EAF61 /* NSMutableData+AppendUTF8.h */,
-				CBEE5CD01CB86989005EAF61 /* NSMutableData+AppendUTF8.m */,
+				CBEE5CCF1CB86989005EAF61 /* NSMutableData+KSCrashAppendUTF8.h */,
+				CBEE5CD01CB86989005EAF61 /* NSMutableData+KSCrashAppendUTF8.m */,
 				CBEE5DBC1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.h */,
 				CBEE5DBD1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.m */,
 			);
@@ -1327,7 +1327,7 @@
 				CBEE5D0C1CB86989005EAF61 /* KSCrashMonitor_CPPException.h in Headers */,
 				CBEE5D521CB86989005EAF61 /* KSCrashReportFilterSets.h in Headers */,
 				CBEE5D541CB86989005EAF61 /* KSCrashReportFilterStringify.h in Headers */,
-				CBEE5D6D1CB86989005EAF61 /* NSMutableData+AppendUTF8.h in Headers */,
+				CBEE5D6D1CB86989005EAF61 /* NSMutableData+KSCrashAppendUTF8.h in Headers */,
 				CBEE5D031CB86989005EAF61 /* KSCrashMonitor_AppState.h in Headers */,
 				CBEE5D671CB86989005EAF61 /* KSHTTPMultipartPostBody.h in Headers */,
 				CBEE5D761CB86989005EAF61 /* Punycode.h in Headers */,
@@ -1409,7 +1409,7 @@
 				F05D783E210204CA00968B97 /* KSCrashMonitor_Deadlock.h in Headers */,
 				F05D7896210204CA00968B97 /* NSError+KSCrashSimpleConstructor.h in Headers */,
 				F05D786A210204CA00968B97 /* KSDate.h in Headers */,
-				F05D78B0210204CA00968B97 /* NSMutableData+AppendUTF8.h in Headers */,
+				F05D78B0210204CA00968B97 /* NSMutableData+KSCrashAppendUTF8.h in Headers */,
 				F05D7835210204CA00968B97 /* KSCrashReportFixer.h in Headers */,
 				F05D783D210204CA00968B97 /* KSCrashMonitor_CPPException.h in Headers */,
 				F05D7842210204CA00968B97 /* KSCrashMonitor_NSException.h in Headers */,
@@ -1602,7 +1602,7 @@
 				8A2507331DA876C300D7F158 /* KSCrashInstallationQuincyHockey_Tests.m in Sources */,
 				8A2507451DA876C300D7F158 /* KSJSONCodec_Tests.m in Sources */,
 				8A25073F1DA876C300D7F158 /* KSCrashSentry_Tests.m in Sources */,
-				8A2507521DA876C300D7F158 /* NSMutableData+AppendUTF8_Tests.m in Sources */,
+				8A2507521DA876C300D7F158 /* NSMutableData+KSCrashAppendUTF8_Tests.m in Sources */,
 				8A25073E1DA876C300D7F158 /* KSCrashSentry_Signal_Tests.m in Sources */,
 				8A25073A1DA876C300D7F158 /* KSCrashReportFilterJSON_Tests.m in Sources */,
 				8A2507381DA876C300D7F158 /* KSCrashReportFilterAlert_Tests.m in Sources */,
@@ -1677,7 +1677,7 @@
 				CBA8A0D51E25D3AB0019B5B9 /* KSCrashCachedData.c in Sources */,
 				CBEE5CF41CB86989005EAF61 /* KSCrash.m in Sources */,
 				CB2851071E02158900C90D80 /* KSID.c in Sources */,
-				CBEE5D6E1CB86989005EAF61 /* NSMutableData+AppendUTF8.m in Sources */,
+				CBEE5D6E1CB86989005EAF61 /* NSMutableData+KSCrashAppendUTF8.m in Sources */,
 				CBEE5D101CB86989005EAF61 /* KSCrashMonitor_MachException.c in Sources */,
 				CBEE5D751CB86989005EAF61 /* Punycode.cpp in Sources */,
 				CBEE5D261CB86989005EAF61 /* KSJSONCodecObjC.m in Sources */,
@@ -1753,7 +1753,7 @@
 				F05D77F32101FBF300968B97 /* KSHTTPMultipartPostBody.m in Sources */,
 				F05D77F52101FBF300968B97 /* KSHTTPRequestSender.m in Sources */,
 				F05D77F72101FBF300968B97 /* KSReachabilityKSCrash.m in Sources */,
-				F05D77F92101FBF300968B97 /* NSMutableData+AppendUTF8.m in Sources */,
+				F05D77F92101FBF300968B97 /* NSMutableData+KSCrashAppendUTF8.m in Sources */,
 				F05D77FB2101FBF300968B97 /* NSString+KSCrashURLEncode.m in Sources */,
 				F05D77FE2101FBF300968B97 /* KSCrashInstallation.m in Sources */,
 				F05D78002101FBF300968B97 /* KSCrashInstallation+Alert.m in Sources */,

--- a/TVOS/KSCrash-TVOS.xcodeproj/project.pbxproj
+++ b/TVOS/KSCrash-TVOS.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 		8A25074C1DA876C300D7F158 /* KSSysCtl_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2507261DA876C300D7F158 /* KSSysCtl_Tests.m */; };
 		8A25074D1DA876C300D7F158 /* KSSystemInfo_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2507271DA876C300D7F158 /* KSSystemInfo_Tests.m */; };
 		8A25074F1DA876C300D7F158 /* NSData+Gzip_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2507291DA876C300D7F158 /* NSData+Gzip_Tests.m */; };
-		8A2507511DA876C300D7F158 /* NSError+SimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A25072B1DA876C300D7F158 /* NSError+SimpleConstructor_Tests.m */; };
+		8A2507511DA876C300D7F158 /* NSError+KSCrashSimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A25072B1DA876C300D7F158 /* NSError+KSCrashSimpleConstructor_Tests.m */; };
 		8A2507521DA876C300D7F158 /* NSMutableData+AppendUTF8_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A25072C1DA876C300D7F158 /* NSMutableData+AppendUTF8_Tests.m */; };
 		8A2507541DA876C300D7F158 /* XCTestCase+KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A25072F1DA876C300D7F158 /* XCTestCase+KSCrash.m */; };
 		CB1806901E0DA06E00239506 /* KSStackCursor_Backtrace.c in Sources */ = {isa = PBXBuildFile; fileRef = CB18068A1E0DA06E00239506 /* KSStackCursor_Backtrace.c */; };
@@ -160,8 +160,8 @@
 		CBEE5D3A1CB86989005EAF61 /* KSSysCtl.c in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5C971CB86989005EAF61 /* KSSysCtl.c */; };
 		CBEE5D3B1CB86989005EAF61 /* KSSysCtl.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C981CB86989005EAF61 /* KSSysCtl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBEE5D3C1CB86989005EAF61 /* KSCrashMonitor_Zombie.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C991CB86989005EAF61 /* KSCrashMonitor_Zombie.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBEE5D401CB86989005EAF61 /* NSError+SimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C9D1CB86989005EAF61 /* NSError+SimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBEE5D411CB86989005EAF61 /* NSError+SimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5C9E1CB86989005EAF61 /* NSError+SimpleConstructor.m */; };
+		CBEE5D401CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C9D1CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBEE5D411CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5C9E1CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.m */; };
 		CBEE5D461CB86989005EAF61 /* KSCrashReportFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CA51CB86989005EAF61 /* KSCrashReportFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBEE5D481CB86989005EAF61 /* KSCrashReportFilterAlert.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CA71CB86989005EAF61 /* KSCrashReportFilterAlert.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBEE5D491CB86989005EAF61 /* KSCrashReportFilterAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CA81CB86989005EAF61 /* KSCrashReportFilterAlert.m */; };
@@ -291,7 +291,7 @@
 		F05D77472101FB0600968B97 /* KSSymbolicator.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CB5658001E1DD448005A8302 /* KSSymbolicator.h */; };
 		F05D77482101FB0600968B97 /* KSSysCtl.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C981CB86989005EAF61 /* KSSysCtl.h */; };
 		F05D77492101FB0600968B97 /* KSThread.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CB25A5E61DF2370300EC2B02 /* KSThread.h */; };
-		F05D774A2101FB0600968B97 /* NSError+SimpleConstructor.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C9D1CB86989005EAF61 /* NSError+SimpleConstructor.h */; };
+		F05D774A2101FB0600968B97 /* NSError+KSCrashSimpleConstructor.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C9D1CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.h */; };
 		F05D774B2101FB4300968B97 /* KSCrashReportSinkConsole.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CBC1CB86989005EAF61 /* KSCrashReportSinkConsole.h */; };
 		F05D774C2101FB4300968B97 /* KSCrashReportSinkEMail.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CBE1CB86989005EAF61 /* KSCrashReportSinkEMail.h */; };
 		F05D774D2101FB4300968B97 /* KSCrashReportSinkQuincyHockey.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CC01CB86989005EAF61 /* KSCrashReportSinkQuincyHockey.h */; };
@@ -358,7 +358,7 @@
 		F05D77CA2101FBF300968B97 /* KSSymbolicator.c in Sources */ = {isa = PBXBuildFile; fileRef = CB5657FF1E1DD448005A8302 /* KSSymbolicator.c */; };
 		F05D77CC2101FBF300968B97 /* KSSysCtl.c in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5C971CB86989005EAF61 /* KSSysCtl.c */; };
 		F05D77CE2101FBF300968B97 /* KSThread.c in Sources */ = {isa = PBXBuildFile; fileRef = CB25A5E51DF2370300EC2B02 /* KSThread.c */; };
-		F05D77D12101FBF300968B97 /* NSError+SimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5C9E1CB86989005EAF61 /* NSError+SimpleConstructor.m */; };
+		F05D77D12101FBF300968B97 /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5C9E1CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.m */; };
 		F05D77D42101FBF300968B97 /* KSCrashReportFilterAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CA81CB86989005EAF61 /* KSCrashReportFilterAlert.m */; };
 		F05D77D62101FBF300968B97 /* KSCrashReportFilterAppleFmt.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CAA1CB86989005EAF61 /* KSCrashReportFilterAppleFmt.m */; };
 		F05D77D82101FBF300968B97 /* KSCrashReportFilterBasic.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CAC1CB86989005EAF61 /* KSCrashReportFilterBasic.m */; };
@@ -475,7 +475,7 @@
 		F05D7890210204CA00968B97 /* KSString.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C961CB86989005EAF61 /* KSString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D7892210204CA00968B97 /* KSSymbolicator.h in Headers */ = {isa = PBXBuildFile; fileRef = CB5658001E1DD448005A8302 /* KSSymbolicator.h */; };
 		F05D7894210204CA00968B97 /* KSSysCtl.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C981CB86989005EAF61 /* KSSysCtl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F05D7896210204CA00968B97 /* NSError+SimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C9D1CB86989005EAF61 /* NSError+SimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F05D7896210204CA00968B97 /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C9D1CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D789F210204CA00968B97 /* Container+DeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB61CB86989005EAF61 /* Container+DeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D78A1210204CA00968B97 /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB81CB86989005EAF61 /* KSVarArgs.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D78A8210204CA00968B97 /* KSCString.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CC71CB86989005EAF61 /* KSCString.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -551,7 +551,7 @@
 				F05D77472101FB0600968B97 /* KSSymbolicator.h in Copy Headers */,
 				F05D77482101FB0600968B97 /* KSSysCtl.h in Copy Headers */,
 				F05D77492101FB0600968B97 /* KSThread.h in Copy Headers */,
-				F05D774A2101FB0600968B97 /* NSError+SimpleConstructor.h in Copy Headers */,
+				F05D774A2101FB0600968B97 /* NSError+KSCrashSimpleConstructor.h in Copy Headers */,
 				F05D77282101FADB00968B97 /* Demangle.h in Copy Headers */,
 				F05D77292101FADB00968B97 /* DemangleNodes.h in Copy Headers */,
 				F05D772A2101FADB00968B97 /* Fallthrough.h in Copy Headers */,
@@ -640,7 +640,7 @@
 		8A2507261DA876C300D7F158 /* KSSysCtl_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSSysCtl_Tests.m; path = "../../Source/KSCrash-Tests/KSSysCtl_Tests.m"; sourceTree = "<group>"; };
 		8A2507271DA876C300D7F158 /* KSSystemInfo_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSSystemInfo_Tests.m; path = "../../Source/KSCrash-Tests/KSSystemInfo_Tests.m"; sourceTree = "<group>"; };
 		8A2507291DA876C300D7F158 /* NSData+Gzip_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+Gzip_Tests.m"; path = "../../Source/KSCrash-Tests/NSData+Gzip_Tests.m"; sourceTree = "<group>"; };
-		8A25072B1DA876C300D7F158 /* NSError+SimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+SimpleConstructor_Tests.m"; path = "../../Source/KSCrash-Tests/NSError+SimpleConstructor_Tests.m"; sourceTree = "<group>"; };
+		8A25072B1DA876C300D7F158 /* NSError+KSCrashSimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+KSCrashSimpleConstructor_Tests.m"; path = "../../Source/KSCrash-Tests/NSError+KSCrashSimpleConstructor_Tests.m"; sourceTree = "<group>"; };
 		8A25072C1DA876C300D7F158 /* NSMutableData+AppendUTF8_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+AppendUTF8_Tests.m"; path = "../../Source/KSCrash-Tests/NSMutableData+AppendUTF8_Tests.m"; sourceTree = "<group>"; };
 		8A25072E1DA876C300D7F158 /* XCTestCase+KSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+KSCrash.h"; path = "../../Source/KSCrash-Tests/XCTestCase+KSCrash.h"; sourceTree = "<group>"; };
 		8A25072F1DA876C300D7F158 /* XCTestCase+KSCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+KSCrash.m"; path = "../../Source/KSCrash-Tests/XCTestCase+KSCrash.m"; sourceTree = "<group>"; };
@@ -765,8 +765,8 @@
 		CBEE5C971CB86989005EAF61 /* KSSysCtl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = KSSysCtl.c; sourceTree = "<group>"; };
 		CBEE5C981CB86989005EAF61 /* KSSysCtl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSSysCtl.h; sourceTree = "<group>"; };
 		CBEE5C991CB86989005EAF61 /* KSCrashMonitor_Zombie.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSCrashMonitor_Zombie.h; sourceTree = "<group>"; };
-		CBEE5C9D1CB86989005EAF61 /* NSError+SimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSError+SimpleConstructor.h"; sourceTree = "<group>"; };
-		CBEE5C9E1CB86989005EAF61 /* NSError+SimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+SimpleConstructor.m"; sourceTree = "<group>"; };
+		CBEE5C9D1CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSError+KSCrashSimpleConstructor.h"; sourceTree = "<group>"; };
+		CBEE5C9E1CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+KSCrashSimpleConstructor.m"; sourceTree = "<group>"; };
 		CBEE5CA51CB86989005EAF61 /* KSCrashReportFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSCrashReportFilter.h; sourceTree = "<group>"; };
 		CBEE5CA71CB86989005EAF61 /* KSCrashReportFilterAlert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSCrashReportFilterAlert.h; sourceTree = "<group>"; };
 		CBEE5CA81CB86989005EAF61 /* KSCrashReportFilterAlert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashReportFilterAlert.m; sourceTree = "<group>"; };
@@ -887,7 +887,7 @@
 				8A2507261DA876C300D7F158 /* KSSysCtl_Tests.m */,
 				8A2507271DA876C300D7F158 /* KSSystemInfo_Tests.m */,
 				8A2507291DA876C300D7F158 /* NSData+Gzip_Tests.m */,
-				8A25072B1DA876C300D7F158 /* NSError+SimpleConstructor_Tests.m */,
+				8A25072B1DA876C300D7F158 /* NSError+KSCrashSimpleConstructor_Tests.m */,
 				8A25072C1DA876C300D7F158 /* NSMutableData+AppendUTF8_Tests.m */,
 				8A25072E1DA876C300D7F158 /* XCTestCase+KSCrash.h */,
 				8A25072F1DA876C300D7F158 /* XCTestCase+KSCrash.m */,
@@ -1109,8 +1109,8 @@
 				CBEE5C981CB86989005EAF61 /* KSSysCtl.h */,
 				CB25A5E51DF2370300EC2B02 /* KSThread.c */,
 				CB25A5E61DF2370300EC2B02 /* KSThread.h */,
-				CBEE5C9D1CB86989005EAF61 /* NSError+SimpleConstructor.h */,
-				CBEE5C9E1CB86989005EAF61 /* NSError+SimpleConstructor.m */,
+				CBEE5C9D1CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.h */,
+				CBEE5C9E1CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.m */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -1332,7 +1332,7 @@
 				CBEE5D671CB86989005EAF61 /* KSHTTPMultipartPostBody.h in Headers */,
 				CBEE5D761CB86989005EAF61 /* Punycode.h in Headers */,
 				CB9821B51DFA142800164220 /* KSMachineContext.h in Headers */,
-				CBEE5D401CB86989005EAF61 /* NSError+SimpleConstructor.h in Headers */,
+				CBEE5D401CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.h in Headers */,
 				CBEE5CFD1CB86989005EAF61 /* KSCrashReportFields.h in Headers */,
 				CBEE5CF71CB86989005EAF61 /* KSCrashC.h in Headers */,
 				CBEE5CE81CB86989005EAF61 /* KSCrashInstallationVictory.h in Headers */,
@@ -1407,7 +1407,7 @@
 				F05D787B210204CA00968B97 /* KSLogger.h in Headers */,
 				F05D7894210204CA00968B97 /* KSSysCtl.h in Headers */,
 				F05D783E210204CA00968B97 /* KSCrashMonitor_Deadlock.h in Headers */,
-				F05D7896210204CA00968B97 /* NSError+SimpleConstructor.h in Headers */,
+				F05D7896210204CA00968B97 /* NSError+KSCrashSimpleConstructor.h in Headers */,
 				F05D786A210204CA00968B97 /* KSDate.h in Headers */,
 				F05D78B0210204CA00968B97 /* NSMutableData+AppendUTF8.h in Headers */,
 				F05D7835210204CA00968B97 /* KSCrashReportFixer.h in Headers */,
@@ -1594,7 +1594,7 @@
 				8A25073D1DA876C300D7F158 /* KSCrashSentry_NSException_Tests.m in Sources */,
 				8A2507311DA876C300D7F158 /* FileBasedTestCase.m in Sources */,
 				8A2507431DA876C300D7F158 /* KSDynamicLinker_Tests.m in Sources */,
-				8A2507511DA876C300D7F158 /* NSError+SimpleConstructor_Tests.m in Sources */,
+				8A2507511DA876C300D7F158 /* NSError+KSCrashSimpleConstructor_Tests.m in Sources */,
 				8A2507371DA876C300D7F158 /* KSCrashReportFilter_Tests.m in Sources */,
 				8A25074D1DA876C300D7F158 /* KSSystemInfo_Tests.m in Sources */,
 				8A2507351DA876C300D7F158 /* KSCrashInstallationVictory_Tests.m in Sources */,
@@ -1649,7 +1649,7 @@
 				CBEE5D3A1CB86989005EAF61 /* KSSysCtl.c in Sources */,
 				CB25A5FF1DF23B7300EC2B02 /* KSDebug.c in Sources */,
 				CBEE5D681CB86989005EAF61 /* KSHTTPMultipartPostBody.m in Sources */,
-				CBEE5D411CB86989005EAF61 /* NSError+SimpleConstructor.m in Sources */,
+				CBEE5D411CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.m in Sources */,
 				CBEE5D131CB86989005EAF61 /* KSCrashMonitor_NSException.m in Sources */,
 				CBEE5D4B1CB86989005EAF61 /* KSCrashReportFilterAppleFmt.m in Sources */,
 				CBEE5D231CB86989005EAF61 /* KSJSONCodec.c in Sources */,
@@ -1734,7 +1734,7 @@
 				F05D77CA2101FBF300968B97 /* KSSymbolicator.c in Sources */,
 				F05D77CC2101FBF300968B97 /* KSSysCtl.c in Sources */,
 				F05D77CE2101FBF300968B97 /* KSThread.c in Sources */,
-				F05D77D12101FBF300968B97 /* NSError+SimpleConstructor.m in Sources */,
+				F05D77D12101FBF300968B97 /* NSError+KSCrashSimpleConstructor.m in Sources */,
 				F05D77D42101FBF300968B97 /* KSCrashReportFilterAlert.m in Sources */,
 				F05D77D62101FBF300968B97 /* KSCrashReportFilterAppleFmt.m in Sources */,
 				F05D77D82101FBF300968B97 /* KSCrashReportFilterBasic.m in Sources */,

--- a/TVOS/KSCrash-TVOS.xcodeproj/project.pbxproj
+++ b/TVOS/KSCrash-TVOS.xcodeproj/project.pbxproj
@@ -214,8 +214,8 @@
 		CBEE5D781CB86989005EAF61 /* SwiftStrings.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CDC1CB86989005EAF61 /* SwiftStrings.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBEE5D7D1CB86A1A005EAF61 /* KSCrashAblyForkFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5D7B1CB86A1A005EAF61 /* KSCrashAblyForkFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBEE5D7F1CB86ABE005EAF61 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CBEE5D7E1CB86ABE005EAF61 /* libz.tbd */; };
-		CBEE5DBE1CBC14CF005EAF61 /* NSString+URLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DBC1CBC14CF005EAF61 /* NSString+URLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBEE5DBF1CBC14CF005EAF61 /* NSString+URLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DBD1CBC14CF005EAF61 /* NSString+URLEncode.m */; };
+		CBEE5DBE1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DBC1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBEE5DBF1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DBD1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.m */; };
 		F05D76EF2101F9A800968B97 /* KSCrashC.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C521CB86989005EAF61 /* KSCrashC.h */; };
 		F05D76F12101F9A800968B97 /* KSCrashCachedData.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBA8A0D41E25D3AB0019B5B9 /* KSCrashCachedData.h */; };
 		F05D76F22101F9A800968B97 /* KSCrashDoctor.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C541CB86989005EAF61 /* KSCrashDoctor.h */; };
@@ -302,7 +302,7 @@
 		F05D77522101FB4300968B97 /* KSHTTPRequestSender.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCB1CB86989005EAF61 /* KSHTTPRequestSender.h */; };
 		F05D77532101FB4300968B97 /* KSReachabilityKSCrash.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCD1CB86989005EAF61 /* KSReachabilityKSCrash.h */; };
 		F05D77542101FB4300968B97 /* NSMutableData+AppendUTF8.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCF1CB86989005EAF61 /* NSMutableData+AppendUTF8.h */; };
-		F05D77552101FB4300968B97 /* NSString+URLEncode.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DBC1CBC14CF005EAF61 /* NSString+URLEncode.h */; };
+		F05D77552101FB4300968B97 /* NSString+KSCrashURLEncode.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DBC1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.h */; };
 		F05D77562101FB4300968B97 /* KSCrashInstallation+Private.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C331CB86989005EAF61 /* KSCrashInstallation+Private.h */; };
 		F05D77572101FB4300968B97 /* KSCrashInstallation.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C341CB86989005EAF61 /* KSCrashInstallation.h */; };
 		F05D77582101FB4300968B97 /* KSCrashInstallation+Alert.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CB8F1DD81CCAF43A0022CDF0 /* KSCrashInstallation+Alert.h */; };
@@ -378,7 +378,7 @@
 		F05D77F52101FBF300968B97 /* KSHTTPRequestSender.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CCC1CB86989005EAF61 /* KSHTTPRequestSender.m */; };
 		F05D77F72101FBF300968B97 /* KSReachabilityKSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CCE1CB86989005EAF61 /* KSReachabilityKSCrash.m */; };
 		F05D77F92101FBF300968B97 /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CD01CB86989005EAF61 /* NSMutableData+AppendUTF8.m */; };
-		F05D77FB2101FBF300968B97 /* NSString+URLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DBD1CBC14CF005EAF61 /* NSString+URLEncode.m */; };
+		F05D77FB2101FBF300968B97 /* NSString+KSCrashURLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DBD1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.m */; };
 		F05D77FE2101FBF300968B97 /* KSCrashInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5C351CB86989005EAF61 /* KSCrashInstallation.m */; };
 		F05D78002101FBF300968B97 /* KSCrashInstallation+Alert.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8F1DD91CCAF43A0022CDF0 /* KSCrashInstallation+Alert.m */; };
 		F05D78022101FBF300968B97 /* KSCrashInstallationConsole.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5C371CB86989005EAF61 /* KSCrashInstallationConsole.m */; };
@@ -483,7 +483,7 @@
 		F05D78AC210204CA00968B97 /* KSHTTPRequestSender.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCB1CB86989005EAF61 /* KSHTTPRequestSender.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D78AE210204CA00968B97 /* KSReachabilityKSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCD1CB86989005EAF61 /* KSReachabilityKSCrash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D78B0210204CA00968B97 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CCF1CB86989005EAF61 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F05D78B2210204CA00968B97 /* NSString+URLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DBC1CBC14CF005EAF61 /* NSString+URLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F05D78B2210204CA00968B97 /* NSString+KSCrashURLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DBC1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D78C0210208FB00968B97 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F05D78BF210208FB00968B97 /* Foundation.framework */; };
 /* End PBXBuildFile section */
 
@@ -514,7 +514,7 @@
 				F05D77522101FB4300968B97 /* KSHTTPRequestSender.h in Copy Headers */,
 				F05D77532101FB4300968B97 /* KSReachabilityKSCrash.h in Copy Headers */,
 				F05D77542101FB4300968B97 /* NSMutableData+AppendUTF8.h in Copy Headers */,
-				F05D77552101FB4300968B97 /* NSString+URLEncode.h in Copy Headers */,
+				F05D77552101FB4300968B97 /* NSString+KSCrashURLEncode.h in Copy Headers */,
 				F05D77562101FB4300968B97 /* KSCrashInstallation+Private.h in Copy Headers */,
 				F05D77572101FB4300968B97 /* KSCrashInstallation.h in Copy Headers */,
 				F05D77582101FB4300968B97 /* KSCrashInstallation+Alert.h in Copy Headers */,
@@ -820,8 +820,8 @@
 		CBEE5D7B1CB86A1A005EAF61 /* KSCrashAblyForkFramework.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashAblyForkFramework.h; path = ../../Source/Framework/KSCrashAblyForkFramework.h; sourceTree = "<group>"; };
 		CBEE5D7C1CB86A1A005EAF61 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; name = module.modulemap; path = ../../Source/Framework/module.modulemap; sourceTree = "<group>"; };
 		CBEE5D7E1CB86ABE005EAF61 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
-		CBEE5DBC1CBC14CF005EAF61 /* NSString+URLEncode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+URLEncode.h"; sourceTree = "<group>"; };
-		CBEE5DBD1CBC14CF005EAF61 /* NSString+URLEncode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+URLEncode.m"; sourceTree = "<group>"; };
+		CBEE5DBC1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+KSCrashURLEncode.h"; sourceTree = "<group>"; };
+		CBEE5DBD1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+KSCrashURLEncode.m"; sourceTree = "<group>"; };
 		F05D76C62101DF7000968B97 /* libKSCrashLib.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libKSCrashLib.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		F05D78BF210208FB00968B97 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -1191,8 +1191,8 @@
 				CBEE5CCE1CB86989005EAF61 /* KSReachabilityKSCrash.m */,
 				CBEE5CCF1CB86989005EAF61 /* NSMutableData+AppendUTF8.h */,
 				CBEE5CD01CB86989005EAF61 /* NSMutableData+AppendUTF8.m */,
-				CBEE5DBC1CBC14CF005EAF61 /* NSString+URLEncode.h */,
-				CBEE5DBD1CBC14CF005EAF61 /* NSString+URLEncode.m */,
+				CBEE5DBC1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.h */,
+				CBEE5DBD1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.m */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -1292,7 +1292,7 @@
 				CBEE5CEF1CB86989005EAF61 /* AlignOf.h in Headers */,
 				CBA8A0D61E25D3AB0019B5B9 /* KSCrashCachedData.h in Headers */,
 				CBEE5D6B1CB86989005EAF61 /* KSReachabilityKSCrash.h in Headers */,
-				CBEE5DBE1CBC14CF005EAF61 /* NSString+URLEncode.h in Headers */,
+				CBEE5DBE1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.h in Headers */,
 				CBEE5D581CB86989005EAF61 /* KSVarArgs.h in Headers */,
 				CBEE5CED1CB86989005EAF61 /* llvm-config.h in Headers */,
 				CB9821D11DFB42DA00164220 /* KSMach.h in Headers */,
@@ -1397,7 +1397,7 @@
 				F05D7838210204CA00968B97 /* KSCrashReportVersion.h in Headers */,
 				F05D785A210204CA00968B97 /* DemangleNodes.h in Headers */,
 				F05D7837210204CA00968B97 /* KSCrashReportStore.h in Headers */,
-				F05D78B2210204CA00968B97 /* NSString+URLEncode.h in Headers */,
+				F05D78B2210204CA00968B97 /* NSString+KSCrashURLEncode.h in Headers */,
 				F05D7839210204CA00968B97 /* KSSystemCapabilities.h in Headers */,
 				F05D7852210204CA00968B97 /* llvm-config.h in Headers */,
 				F05D7872210204CA00968B97 /* KSDynamicLinker.h in Headers */,
@@ -1643,7 +1643,7 @@
 				CBEE5D211CB86989005EAF61 /* KSFileUtils.c in Sources */,
 				CBEE5CE71CB86989005EAF61 /* KSCrashInstallationStandard.m in Sources */,
 				CBEE5D6C1CB86989005EAF61 /* KSReachabilityKSCrash.m in Sources */,
-				CBEE5DBF1CBC14CF005EAF61 /* NSString+URLEncode.m in Sources */,
+				CBEE5DBF1CBC14CF005EAF61 /* NSString+KSCrashURLEncode.m in Sources */,
 				CBEE5D4F1CB86989005EAF61 /* KSCrashReportFilterGZip.m in Sources */,
 				CB5658031E1DD448005A8302 /* KSSymbolicator.c in Sources */,
 				CBEE5D3A1CB86989005EAF61 /* KSSysCtl.c in Sources */,
@@ -1754,7 +1754,7 @@
 				F05D77F52101FBF300968B97 /* KSHTTPRequestSender.m in Sources */,
 				F05D77F72101FBF300968B97 /* KSReachabilityKSCrash.m in Sources */,
 				F05D77F92101FBF300968B97 /* NSMutableData+AppendUTF8.m in Sources */,
-				F05D77FB2101FBF300968B97 /* NSString+URLEncode.m in Sources */,
+				F05D77FB2101FBF300968B97 /* NSString+KSCrashURLEncode.m in Sources */,
 				F05D77FE2101FBF300968B97 /* KSCrashInstallation.m in Sources */,
 				F05D78002101FBF300968B97 /* KSCrashInstallation+Alert.m in Sources */,
 				F05D78022101FBF300968B97 /* KSCrashInstallationConsole.m in Sources */,

--- a/TVOS/KSCrash-TVOS.xcodeproj/project.pbxproj
+++ b/TVOS/KSCrash-TVOS.xcodeproj/project.pbxproj
@@ -180,8 +180,8 @@
 		CBEE5D561CB86989005EAF61 /* Container+DeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB61CB86989005EAF61 /* Container+DeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBEE5D571CB86989005EAF61 /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CB71CB86989005EAF61 /* Container+DeepSearch.m */; };
 		CBEE5D581CB86989005EAF61 /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB81CB86989005EAF61 /* KSVarArgs.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBEE5D591CB86989005EAF61 /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB91CB86989005EAF61 /* NSData+GZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CBEE5D5A1CB86989005EAF61 /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CBA1CB86989005EAF61 /* NSData+GZip.m */; };
+		CBEE5D591CB86989005EAF61 /* NSData+KSCrashGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB91CB86989005EAF61 /* NSData+KSCrashGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CBEE5D5A1CB86989005EAF61 /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CBA1CB86989005EAF61 /* NSData+KSCrashGZip.m */; };
 		CBEE5D5B1CB86989005EAF61 /* KSCrashReportSinkConsole.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CBC1CB86989005EAF61 /* KSCrashReportSinkConsole.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBEE5D5C1CB86989005EAF61 /* KSCrashReportSinkConsole.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CBD1CB86989005EAF61 /* KSCrashReportSinkConsole.m */; };
 		CBEE5D5D1CB86989005EAF61 /* KSCrashReportSinkEMail.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CBE1CB86989005EAF61 /* KSCrashReportSinkEMail.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -256,7 +256,7 @@
 		F05D77242101FAB700968B97 /* KSCrashReportFilterStringify.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB31CB86989005EAF61 /* KSCrashReportFilterStringify.h */; };
 		F05D77252101FACB00968B97 /* Container+DeepSearch.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB61CB86989005EAF61 /* Container+DeepSearch.h */; };
 		F05D77262101FACB00968B97 /* KSVarArgs.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB81CB86989005EAF61 /* KSVarArgs.h */; };
-		F05D77272101FACB00968B97 /* NSData+GZip.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB91CB86989005EAF61 /* NSData+GZip.h */; };
+		F05D77272101FACB00968B97 /* NSData+KSCrashGZip.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB91CB86989005EAF61 /* NSData+KSCrashGZip.h */; };
 		F05D77282101FADB00968B97 /* Demangle.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CD41CB86989005EAF61 /* Demangle.h */; };
 		F05D77292101FADB00968B97 /* DemangleNodes.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CD51CB86989005EAF61 /* DemangleNodes.h */; };
 		F05D772A2101FADB00968B97 /* Fallthrough.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CD61CB86989005EAF61 /* Fallthrough.h */; };
@@ -367,7 +367,7 @@
 		F05D77DE2101FBF300968B97 /* KSCrashReportFilterSets.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CB21CB86989005EAF61 /* KSCrashReportFilterSets.m */; };
 		F05D77E02101FBF300968B97 /* KSCrashReportFilterStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CB41CB86989005EAF61 /* KSCrashReportFilterStringify.m */; };
 		F05D77E22101FBF300968B97 /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CB71CB86989005EAF61 /* Container+DeepSearch.m */; };
-		F05D77E52101FBF300968B97 /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CBA1CB86989005EAF61 /* NSData+GZip.m */; };
+		F05D77E52101FBF300968B97 /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CBA1CB86989005EAF61 /* NSData+KSCrashGZip.m */; };
 		F05D77E72101FBF300968B97 /* KSCrashReportSinkConsole.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CBD1CB86989005EAF61 /* KSCrashReportSinkConsole.m */; };
 		F05D77E92101FBF300968B97 /* KSCrashReportSinkEMail.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CBF1CB86989005EAF61 /* KSCrashReportSinkEMail.m */; };
 		F05D77EB2101FBF300968B97 /* KSCrashReportSinkQuincyHockey.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CC11CB86989005EAF61 /* KSCrashReportSinkQuincyHockey.m */; };
@@ -414,7 +414,7 @@
 		F05D7825210203C900968B97 /* KSCrashMonitorType.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C601CB86989005EAF61 /* KSCrashMonitorType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F05D78262102043700968B97 /* KSJSONCodecObjC.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C821CB86989005EAF61 /* KSJSONCodecObjC.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F05D78272102044B00968B97 /* KSCrashReportFilterStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB31CB86989005EAF61 /* KSCrashReportFilterStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F05D78282102045B00968B97 /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB91CB86989005EAF61 /* NSData+GZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F05D78282102045B00968B97 /* NSData+KSCrashGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB91CB86989005EAF61 /* NSData+KSCrashGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F05D78292102046900968B97 /* KSMachineContext.h in Headers */ = {isa = PBXBuildFile; fileRef = CB9821B21DFA142800164220 /* KSMachineContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F05D782A2102047600968B97 /* KSCrashInstallation+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C331CB86989005EAF61 /* KSCrashInstallation+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F05D782B2102048300968B97 /* KSCrashC.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C521CB86989005EAF61 /* KSCrashC.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -561,7 +561,7 @@
 				F05D772E2101FADB00968B97 /* SwiftStrings.h in Copy Headers */,
 				F05D77252101FACB00968B97 /* Container+DeepSearch.h in Copy Headers */,
 				F05D77262101FACB00968B97 /* KSVarArgs.h in Copy Headers */,
-				F05D77272101FACB00968B97 /* NSData+GZip.h in Copy Headers */,
+				F05D77272101FACB00968B97 /* NSData+KSCrashGZip.h in Copy Headers */,
 				F05D771D2101FAB700968B97 /* KSCrashReportFilter.h in Copy Headers */,
 				F05D771E2101FAB700968B97 /* KSCrashReportFilterAlert.h in Copy Headers */,
 				F05D771F2101FAB700968B97 /* KSCrashReportFilterAppleFmt.h in Copy Headers */,
@@ -785,8 +785,8 @@
 		CBEE5CB61CB86989005EAF61 /* Container+DeepSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Container+DeepSearch.h"; sourceTree = "<group>"; };
 		CBEE5CB71CB86989005EAF61 /* Container+DeepSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Container+DeepSearch.m"; sourceTree = "<group>"; };
 		CBEE5CB81CB86989005EAF61 /* KSVarArgs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSVarArgs.h; sourceTree = "<group>"; };
-		CBEE5CB91CB86989005EAF61 /* NSData+GZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+GZip.h"; sourceTree = "<group>"; };
-		CBEE5CBA1CB86989005EAF61 /* NSData+GZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+GZip.m"; sourceTree = "<group>"; };
+		CBEE5CB91CB86989005EAF61 /* NSData+KSCrashGZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+KSCrashGZip.h"; sourceTree = "<group>"; };
+		CBEE5CBA1CB86989005EAF61 /* NSData+KSCrashGZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+KSCrashGZip.m"; sourceTree = "<group>"; };
 		CBEE5CBC1CB86989005EAF61 /* KSCrashReportSinkConsole.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSCrashReportSinkConsole.h; sourceTree = "<group>"; };
 		CBEE5CBD1CB86989005EAF61 /* KSCrashReportSinkConsole.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashReportSinkConsole.m; sourceTree = "<group>"; };
 		CBEE5CBE1CB86989005EAF61 /* KSCrashReportSinkEMail.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSCrashReportSinkEMail.h; sourceTree = "<group>"; };
@@ -1155,8 +1155,8 @@
 				CBEE5CB61CB86989005EAF61 /* Container+DeepSearch.h */,
 				CBEE5CB71CB86989005EAF61 /* Container+DeepSearch.m */,
 				CBEE5CB81CB86989005EAF61 /* KSVarArgs.h */,
-				CBEE5CB91CB86989005EAF61 /* NSData+GZip.h */,
-				CBEE5CBA1CB86989005EAF61 /* NSData+GZip.m */,
+				CBEE5CB91CB86989005EAF61 /* NSData+KSCrashGZip.h */,
+				CBEE5CBA1CB86989005EAF61 /* NSData+KSCrashGZip.m */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -1258,7 +1258,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CBEE5CDD1CB86989005EAF61 /* KSCrashInstallation+Private.h in Headers */,
-				CBEE5D591CB86989005EAF61 /* NSData+GZip.h in Headers */,
+				CBEE5D591CB86989005EAF61 /* NSData+KSCrashGZip.h in Headers */,
 				CBEE5D4E1CB86989005EAF61 /* KSCrashReportFilterGZip.h in Headers */,
 				CBEE5D731CB86989005EAF61 /* LLVM.h in Headers */,
 				CB5658021E1DD448005A8302 /* KSStackCursor_SelfThread.h in Headers */,
@@ -1387,7 +1387,7 @@
 				F05D7825210203C900968B97 /* KSCrashMonitorType.h in Headers */,
 				F05D78272102044B00968B97 /* KSCrashReportFilterStringify.h in Headers */,
 				F05D78262102043700968B97 /* KSJSONCodecObjC.h in Headers */,
-				F05D78282102045B00968B97 /* NSData+GZip.h in Headers */,
+				F05D78282102045B00968B97 /* NSData+KSCrashGZip.h in Headers */,
 				F05D78292102046900968B97 /* KSMachineContext.h in Headers */,
 				F05D782A2102047600968B97 /* KSCrashInstallation+Private.h in Headers */,
 				F05D782B2102048300968B97 /* KSCrashC.h in Headers */,
@@ -1633,7 +1633,7 @@
 				CBEE5D5C1CB86989005EAF61 /* KSCrashReportSinkConsole.m in Sources */,
 				CBEE5CE11CB86989005EAF61 /* KSCrashInstallationConsole.m in Sources */,
 				CBEE5D351CB86989005EAF61 /* KSSignalInfo.c in Sources */,
-				CBEE5D5A1CB86989005EAF61 /* NSData+GZip.m in Sources */,
+				CBEE5D5A1CB86989005EAF61 /* NSData+KSCrashGZip.m in Sources */,
 				CBEE5D171CB86989005EAF61 /* KSCrashMonitor_User.c in Sources */,
 				CBEE5D551CB86989005EAF61 /* KSCrashReportFilterStringify.m in Sources */,
 				CBA1A5361DD25043007B1CE7 /* KSCrashReportFixer.c in Sources */,
@@ -1743,7 +1743,7 @@
 				F05D77DE2101FBF300968B97 /* KSCrashReportFilterSets.m in Sources */,
 				F05D77E02101FBF300968B97 /* KSCrashReportFilterStringify.m in Sources */,
 				F05D77E22101FBF300968B97 /* Container+DeepSearch.m in Sources */,
-				F05D77E52101FBF300968B97 /* NSData+GZip.m in Sources */,
+				F05D77E52101FBF300968B97 /* NSData+KSCrashGZip.m in Sources */,
 				F05D77E72101FBF300968B97 /* KSCrashReportSinkConsole.m in Sources */,
 				F05D77E92101FBF300968B97 /* KSCrashReportSinkEMail.m in Sources */,
 				F05D77EB2101FBF300968B97 /* KSCrashReportSinkQuincyHockey.m in Sources */,

--- a/TVOS/KSCrash-TVOS.xcodeproj/project.pbxproj
+++ b/TVOS/KSCrash-TVOS.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		03082CD71D91822300935324 /* KSCrashMonitor_Zombie.c in Sources */ = {isa = PBXBuildFile; fileRef = 03082CD61D91822300935324 /* KSCrashMonitor_Zombie.c */; };
 		8A2507031DA8768E00D7F158 /* KSCrashAblyFork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBEE5C271CB8679E005EAF61 /* KSCrashAblyFork.framework */; };
-		8A2507301DA876C300D7F158 /* Container+DeepSearch_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2507091DA876C300D7F158 /* Container+DeepSearch_Tests.m */; };
+		8A2507301DA876C300D7F158 /* Container+KSCrashDeepSearch_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2507091DA876C300D7F158 /* Container+KSCrashDeepSearch_Tests.m */; };
 		8A2507311DA876C300D7F158 /* FileBasedTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A25070B1DA876C300D7F158 /* FileBasedTestCase.m */; };
 		8A2507321DA876C300D7F158 /* KSCrashInstallationEmail_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A25070C1DA876C300D7F158 /* KSCrashInstallationEmail_Tests.m */; };
 		8A2507331DA876C300D7F158 /* KSCrashInstallationQuincyHockey_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A25070D1DA876C300D7F158 /* KSCrashInstallationQuincyHockey_Tests.m */; };
@@ -177,8 +177,8 @@
 		CBEE5D531CB86989005EAF61 /* KSCrashReportFilterSets.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CB21CB86989005EAF61 /* KSCrashReportFilterSets.m */; };
 		CBEE5D541CB86989005EAF61 /* KSCrashReportFilterStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB31CB86989005EAF61 /* KSCrashReportFilterStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBEE5D551CB86989005EAF61 /* KSCrashReportFilterStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CB41CB86989005EAF61 /* KSCrashReportFilterStringify.m */; };
-		CBEE5D561CB86989005EAF61 /* Container+DeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB61CB86989005EAF61 /* Container+DeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBEE5D571CB86989005EAF61 /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CB71CB86989005EAF61 /* Container+DeepSearch.m */; };
+		CBEE5D561CB86989005EAF61 /* Container+KSCrashDeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB61CB86989005EAF61 /* Container+KSCrashDeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBEE5D571CB86989005EAF61 /* Container+KSCrashDeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CB71CB86989005EAF61 /* Container+KSCrashDeepSearch.m */; };
 		CBEE5D581CB86989005EAF61 /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB81CB86989005EAF61 /* KSVarArgs.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBEE5D591CB86989005EAF61 /* NSData+KSCrashGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB91CB86989005EAF61 /* NSData+KSCrashGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBEE5D5A1CB86989005EAF61 /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CBA1CB86989005EAF61 /* NSData+KSCrashGZip.m */; };
@@ -254,7 +254,7 @@
 		F05D77222101FAB700968B97 /* KSCrashReportFilterJSON.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CAF1CB86989005EAF61 /* KSCrashReportFilterJSON.h */; };
 		F05D77232101FAB700968B97 /* KSCrashReportFilterSets.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB11CB86989005EAF61 /* KSCrashReportFilterSets.h */; };
 		F05D77242101FAB700968B97 /* KSCrashReportFilterStringify.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB31CB86989005EAF61 /* KSCrashReportFilterStringify.h */; };
-		F05D77252101FACB00968B97 /* Container+DeepSearch.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB61CB86989005EAF61 /* Container+DeepSearch.h */; };
+		F05D77252101FACB00968B97 /* Container+KSCrashDeepSearch.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB61CB86989005EAF61 /* Container+KSCrashDeepSearch.h */; };
 		F05D77262101FACB00968B97 /* KSVarArgs.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB81CB86989005EAF61 /* KSVarArgs.h */; };
 		F05D77272101FACB00968B97 /* NSData+KSCrashGZip.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB91CB86989005EAF61 /* NSData+KSCrashGZip.h */; };
 		F05D77282101FADB00968B97 /* Demangle.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CD41CB86989005EAF61 /* Demangle.h */; };
@@ -366,7 +366,7 @@
 		F05D77DC2101FBF300968B97 /* KSCrashReportFilterJSON.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CB01CB86989005EAF61 /* KSCrashReportFilterJSON.m */; };
 		F05D77DE2101FBF300968B97 /* KSCrashReportFilterSets.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CB21CB86989005EAF61 /* KSCrashReportFilterSets.m */; };
 		F05D77E02101FBF300968B97 /* KSCrashReportFilterStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CB41CB86989005EAF61 /* KSCrashReportFilterStringify.m */; };
-		F05D77E22101FBF300968B97 /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CB71CB86989005EAF61 /* Container+DeepSearch.m */; };
+		F05D77E22101FBF300968B97 /* Container+KSCrashDeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CB71CB86989005EAF61 /* Container+KSCrashDeepSearch.m */; };
 		F05D77E52101FBF300968B97 /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CBA1CB86989005EAF61 /* NSData+KSCrashGZip.m */; };
 		F05D77E72101FBF300968B97 /* KSCrashReportSinkConsole.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CBD1CB86989005EAF61 /* KSCrashReportSinkConsole.m */; };
 		F05D77E92101FBF300968B97 /* KSCrashReportSinkEMail.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5CBF1CB86989005EAF61 /* KSCrashReportSinkEMail.m */; };
@@ -476,7 +476,7 @@
 		F05D7892210204CA00968B97 /* KSSymbolicator.h in Headers */ = {isa = PBXBuildFile; fileRef = CB5658001E1DD448005A8302 /* KSSymbolicator.h */; };
 		F05D7894210204CA00968B97 /* KSSysCtl.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C981CB86989005EAF61 /* KSSysCtl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D7896210204CA00968B97 /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C9D1CB86989005EAF61 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F05D789F210204CA00968B97 /* Container+DeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB61CB86989005EAF61 /* Container+DeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F05D789F210204CA00968B97 /* Container+KSCrashDeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB61CB86989005EAF61 /* Container+KSCrashDeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D78A1210204CA00968B97 /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CB81CB86989005EAF61 /* KSVarArgs.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D78A8210204CA00968B97 /* KSCString.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CC71CB86989005EAF61 /* KSCString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F05D78AA210204CA00968B97 /* KSHTTPMultipartPostBody.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5CC91CB86989005EAF61 /* KSHTTPMultipartPostBody.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -559,7 +559,7 @@
 				F05D772C2101FADB00968B97 /* Malloc.h in Copy Headers */,
 				F05D772D2101FADB00968B97 /* Punycode.h in Copy Headers */,
 				F05D772E2101FADB00968B97 /* SwiftStrings.h in Copy Headers */,
-				F05D77252101FACB00968B97 /* Container+DeepSearch.h in Copy Headers */,
+				F05D77252101FACB00968B97 /* Container+KSCrashDeepSearch.h in Copy Headers */,
 				F05D77262101FACB00968B97 /* KSVarArgs.h in Copy Headers */,
 				F05D77272101FACB00968B97 /* NSData+KSCrashGZip.h in Copy Headers */,
 				F05D771D2101FAB700968B97 /* KSCrashReportFilter.h in Copy Headers */,
@@ -610,7 +610,7 @@
 		03082CD61D91822300935324 /* KSCrashMonitor_Zombie.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = KSCrashMonitor_Zombie.c; sourceTree = "<group>"; };
 		8A2506FE1DA8768E00D7F158 /* KSCrashTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KSCrashTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A2507021DA8768E00D7F158 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8A2507091DA876C300D7F158 /* Container+DeepSearch_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+DeepSearch_Tests.m"; path = "../../Source/KSCrash-Tests/Container+DeepSearch_Tests.m"; sourceTree = "<group>"; };
+		8A2507091DA876C300D7F158 /* Container+KSCrashDeepSearch_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+KSCrashDeepSearch_Tests.m"; path = "../../Source/KSCrash-Tests/Container+KSCrashDeepSearch_Tests.m"; sourceTree = "<group>"; };
 		8A25070A1DA876C300D7F158 /* FileBasedTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FileBasedTestCase.h; path = "../../Source/KSCrash-Tests/FileBasedTestCase.h"; sourceTree = "<group>"; };
 		8A25070B1DA876C300D7F158 /* FileBasedTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FileBasedTestCase.m; path = "../../Source/KSCrash-Tests/FileBasedTestCase.m"; sourceTree = "<group>"; };
 		8A25070C1DA876C300D7F158 /* KSCrashInstallationEmail_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashInstallationEmail_Tests.m; path = "../../Source/KSCrash-Tests/KSCrashInstallationEmail_Tests.m"; sourceTree = "<group>"; };
@@ -782,8 +782,8 @@
 		CBEE5CB21CB86989005EAF61 /* KSCrashReportFilterSets.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashReportFilterSets.m; sourceTree = "<group>"; };
 		CBEE5CB31CB86989005EAF61 /* KSCrashReportFilterStringify.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSCrashReportFilterStringify.h; sourceTree = "<group>"; };
 		CBEE5CB41CB86989005EAF61 /* KSCrashReportFilterStringify.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashReportFilterStringify.m; sourceTree = "<group>"; };
-		CBEE5CB61CB86989005EAF61 /* Container+DeepSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Container+DeepSearch.h"; sourceTree = "<group>"; };
-		CBEE5CB71CB86989005EAF61 /* Container+DeepSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Container+DeepSearch.m"; sourceTree = "<group>"; };
+		CBEE5CB61CB86989005EAF61 /* Container+KSCrashDeepSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Container+KSCrashDeepSearch.h"; sourceTree = "<group>"; };
+		CBEE5CB71CB86989005EAF61 /* Container+KSCrashDeepSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Container+KSCrashDeepSearch.m"; sourceTree = "<group>"; };
 		CBEE5CB81CB86989005EAF61 /* KSVarArgs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSVarArgs.h; sourceTree = "<group>"; };
 		CBEE5CB91CB86989005EAF61 /* NSData+KSCrashGZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+KSCrashGZip.h"; sourceTree = "<group>"; };
 		CBEE5CBA1CB86989005EAF61 /* NSData+KSCrashGZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+KSCrashGZip.m"; sourceTree = "<group>"; };
@@ -857,7 +857,7 @@
 		8A2506FF1DA8768E00D7F158 /* KSCrashTests */ = {
 			isa = PBXGroup;
 			children = (
-				8A2507091DA876C300D7F158 /* Container+DeepSearch_Tests.m */,
+				8A2507091DA876C300D7F158 /* Container+KSCrashDeepSearch_Tests.m */,
 				8A25070A1DA876C300D7F158 /* FileBasedTestCase.h */,
 				8A25070B1DA876C300D7F158 /* FileBasedTestCase.m */,
 				8A25070C1DA876C300D7F158 /* KSCrashInstallationEmail_Tests.m */,
@@ -1152,8 +1152,8 @@
 		CBEE5CB51CB86989005EAF61 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
-				CBEE5CB61CB86989005EAF61 /* Container+DeepSearch.h */,
-				CBEE5CB71CB86989005EAF61 /* Container+DeepSearch.m */,
+				CBEE5CB61CB86989005EAF61 /* Container+KSCrashDeepSearch.h */,
+				CBEE5CB71CB86989005EAF61 /* Container+KSCrashDeepSearch.m */,
 				CBEE5CB81CB86989005EAF61 /* KSVarArgs.h */,
 				CBEE5CB91CB86989005EAF61 /* NSData+KSCrashGZip.h */,
 				CBEE5CBA1CB86989005EAF61 /* NSData+KSCrashGZip.m */,
@@ -1319,7 +1319,7 @@
 				CBEE5D501CB86989005EAF61 /* KSCrashReportFilterJSON.h in Headers */,
 				CBEE5D5B1CB86989005EAF61 /* KSCrashReportSinkConsole.h in Headers */,
 				CB1806951E0DA06E00239506 /* KSStackCursor.h in Headers */,
-				CBEE5D561CB86989005EAF61 /* Container+DeepSearch.h in Headers */,
+				CBEE5D561CB86989005EAF61 /* Container+KSCrashDeepSearch.h in Headers */,
 				CBEE5D181CB86989005EAF61 /* KSCrashMonitor_User.h in Headers */,
 				CBEE5D061CB86989005EAF61 /* KSSystemCapabilities.h in Headers */,
 				CBEE5D321CB86989005EAF61 /* KSObjCApple.h in Headers */,
@@ -1436,7 +1436,7 @@
 				F05D7833210204CA00968B97 /* KSCrashReportFields.h in Headers */,
 				F05D7841210204CA00968B97 /* KSCrashMonitor_MachException.h in Headers */,
 				F05D7854210204CA00968B97 /* AlignOf.h in Headers */,
-				F05D789F210204CA00968B97 /* Container+DeepSearch.h in Headers */,
+				F05D789F210204CA00968B97 /* Container+KSCrashDeepSearch.h in Headers */,
 				F05D78AA210204CA00968B97 /* KSHTTPMultipartPostBody.h in Headers */,
 				F05D7845210204CA00968B97 /* KSCrashMonitor_Signal.h in Headers */,
 				F05D78AE210204CA00968B97 /* KSReachabilityKSCrash.h in Headers */,
@@ -1612,7 +1612,7 @@
 				8A2507441DA876C300D7F158 /* KSFileUtils_Tests.m in Sources */,
 				8A2507481DA876C300D7F158 /* KSObjC_Tests.m in Sources */,
 				8A2507361DA876C300D7F158 /* KSCrashReportConverter_Tests.m in Sources */,
-				8A2507301DA876C300D7F158 /* Container+DeepSearch_Tests.m in Sources */,
+				8A2507301DA876C300D7F158 /* Container+KSCrashDeepSearch_Tests.m in Sources */,
 				8A2507421DA876C300D7F158 /* KSCString_Tests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1665,7 +1665,7 @@
 				CB69B8EC1DC0F195002713B1 /* KSCrashReportStore.c in Sources */,
 				CBEE5CF61CB86989005EAF61 /* KSCrashC.c in Sources */,
 				CB69B8D71DC044A7002713B1 /* KSDate.c in Sources */,
-				CBEE5D571CB86989005EAF61 /* Container+DeepSearch.m in Sources */,
+				CBEE5D571CB86989005EAF61 /* Container+KSCrashDeepSearch.m in Sources */,
 				CBEE5D291CB86989005EAF61 /* KSMemory.c in Sources */,
 				03082CD71D91822300935324 /* KSCrashMonitor_Zombie.c in Sources */,
 				CBEE5D641CB86989005EAF61 /* KSCrashReportSinkVictory.m in Sources */,
@@ -1742,7 +1742,7 @@
 				F05D77DC2101FBF300968B97 /* KSCrashReportFilterJSON.m in Sources */,
 				F05D77DE2101FBF300968B97 /* KSCrashReportFilterSets.m in Sources */,
 				F05D77E02101FBF300968B97 /* KSCrashReportFilterStringify.m in Sources */,
-				F05D77E22101FBF300968B97 /* Container+DeepSearch.m in Sources */,
+				F05D77E22101FBF300968B97 /* Container+KSCrashDeepSearch.m in Sources */,
 				F05D77E52101FBF300968B97 /* NSData+KSCrashGZip.m in Sources */,
 				F05D77E72101FBF300968B97 /* KSCrashReportSinkConsole.m in Sources */,
 				F05D77E92101FBF300968B97 /* KSCrashReportSinkEMail.m in Sources */,

--- a/WatchOS/KSCrash.xcodeproj/project.pbxproj
+++ b/WatchOS/KSCrash.xcodeproj/project.pbxproj
@@ -148,8 +148,8 @@
 		CB7370561D9B6FD000E3230F /* KSHTTPRequestSender.m in Sources */ = {isa = PBXBuildFile; fileRef = CB73704A1D9B6FD000E3230F /* KSHTTPRequestSender.m */; };
 		CB7370591D9B6FD000E3230F /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CB73704D1D9B6FD000E3230F /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB73705A1D9B6FD000E3230F /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CB73704E1D9B6FD000E3230F /* NSMutableData+AppendUTF8.m */; };
-		CB73705B1D9B6FD000E3230F /* NSString+URLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CB73704F1D9B6FD000E3230F /* NSString+URLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CB73705C1D9B6FD000E3230F /* NSString+URLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7370501D9B6FD000E3230F /* NSString+URLEncode.m */; };
+		CB73705B1D9B6FD000E3230F /* NSString+KSCrashURLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CB73704F1D9B6FD000E3230F /* NSString+KSCrashURLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CB73705C1D9B6FD000E3230F /* NSString+KSCrashURLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7370501D9B6FD000E3230F /* NSString+KSCrashURLEncode.m */; };
 		CB73706D1D9B6FE500E3230F /* KSCrashInstallation+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB73705E1D9B6FE500E3230F /* KSCrashInstallation+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB73706E1D9B6FE500E3230F /* KSCrashInstallation.h in Headers */ = {isa = PBXBuildFile; fileRef = CB73705F1D9B6FE500E3230F /* KSCrashInstallation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB73706F1D9B6FE500E3230F /* KSCrashInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7370601D9B6FE500E3230F /* KSCrashInstallation.m */; };
@@ -330,8 +330,8 @@
 		CB73704C1D9B6FD000E3230F /* KSReachabilityKSCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSReachabilityKSCrash.m; path = ../../Source/KSCrash/Reporting/Tools/KSReachabilityKSCrash.m; sourceTree = "<group>"; };
 		CB73704D1D9B6FD000E3230F /* NSMutableData+AppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableData+AppendUTF8.h"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.h"; sourceTree = "<group>"; };
 		CB73704E1D9B6FD000E3230F /* NSMutableData+AppendUTF8.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+AppendUTF8.m"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.m"; sourceTree = "<group>"; };
-		CB73704F1D9B6FD000E3230F /* NSString+URLEncode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+URLEncode.h"; path = "../../Source/KSCrash/Reporting/Tools/NSString+URLEncode.h"; sourceTree = "<group>"; };
-		CB7370501D9B6FD000E3230F /* NSString+URLEncode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+URLEncode.m"; path = "../../Source/KSCrash/Reporting/Tools/NSString+URLEncode.m"; sourceTree = "<group>"; };
+		CB73704F1D9B6FD000E3230F /* NSString+KSCrashURLEncode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+KSCrashURLEncode.h"; path = "../../Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.h"; sourceTree = "<group>"; };
+		CB7370501D9B6FD000E3230F /* NSString+KSCrashURLEncode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+KSCrashURLEncode.m"; path = "../../Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.m"; sourceTree = "<group>"; };
 		CB73705E1D9B6FE500E3230F /* KSCrashInstallation+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "KSCrashInstallation+Private.h"; path = "../../Source/KSCrash/Installations/KSCrashInstallation+Private.h"; sourceTree = "<group>"; };
 		CB73705F1D9B6FE500E3230F /* KSCrashInstallation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashInstallation.h; path = ../../Source/KSCrash/Installations/KSCrashInstallation.h; sourceTree = "<group>"; };
 		CB7370601D9B6FE500E3230F /* KSCrashInstallation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashInstallation.m; path = ../../Source/KSCrash/Installations/KSCrashInstallation.m; sourceTree = "<group>"; };
@@ -669,8 +669,8 @@
 				CB73704C1D9B6FD000E3230F /* KSReachabilityKSCrash.m */,
 				CB73704D1D9B6FD000E3230F /* NSMutableData+AppendUTF8.h */,
 				CB73704E1D9B6FD000E3230F /* NSMutableData+AppendUTF8.m */,
-				CB73704F1D9B6FD000E3230F /* NSString+URLEncode.h */,
-				CB7370501D9B6FD000E3230F /* NSString+URLEncode.m */,
+				CB73704F1D9B6FD000E3230F /* NSString+KSCrashURLEncode.h */,
+				CB7370501D9B6FD000E3230F /* NSString+KSCrashURLEncode.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -719,7 +719,7 @@
 				CB736FE61D9B6F5500E3230F /* llvm-config.h in Headers */,
 				CB736F7D1D9B6EF500E3230F /* KSCrashMonitor_Signal.h in Headers */,
 				CB73702E1D9B6FB900E3230F /* KSVarArgs.h in Headers */,
-				CB73705B1D9B6FD000E3230F /* NSString+URLEncode.h in Headers */,
+				CB73705B1D9B6FD000E3230F /* NSString+KSCrashURLEncode.h in Headers */,
 				CB56580A1E1DD4D0005A8302 /* KSStackCursor_SelfThread.h in Headers */,
 				CB7370741D9B6FE500E3230F /* KSCrashInstallationEmail.h in Headers */,
 				CB736F581D9B6ECD00E3230F /* KSCrashMonitor_AppState.h in Headers */,
@@ -904,7 +904,7 @@
 				CB7370001D9B6F7800E3230F /* Punycode.cpp in Sources */,
 				CB73707B1D9B6FE500E3230F /* KSCrashInstallationVictory.m in Sources */,
 				CB7370191D9B6FA800E3230F /* KSCrashReportFilterAlert.m in Sources */,
-				CB73705C1D9B6FD000E3230F /* NSString+URLEncode.m in Sources */,
+				CB73705C1D9B6FD000E3230F /* NSString+KSCrashURLEncode.m in Sources */,
 				CB736FD11D9B6F0E00E3230F /* KSCrashMonitor_Zombie.c in Sources */,
 				CB736FBD1D9B6F0E00E3230F /* KSMemory.c in Sources */,
 				CB56580B1E1DD4D0005A8302 /* KSSymbolicator.c in Sources */,

--- a/WatchOS/KSCrash.xcodeproj/project.pbxproj
+++ b/WatchOS/KSCrash.xcodeproj/project.pbxproj
@@ -91,8 +91,8 @@
 		CB736FCF1D9B6F0E00E3230F /* KSSysCtl.h in Headers */ = {isa = PBXBuildFile; fileRef = CB736FA21D9B6F0E00E3230F /* KSSysCtl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB736FD01D9B6F0E00E3230F /* KSCrashMonitor_Zombie.h in Headers */ = {isa = PBXBuildFile; fileRef = CB736FA31D9B6F0E00E3230F /* KSCrashMonitor_Zombie.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB736FD11D9B6F0E00E3230F /* KSCrashMonitor_Zombie.c in Sources */ = {isa = PBXBuildFile; fileRef = CB736FA41D9B6F0E00E3230F /* KSCrashMonitor_Zombie.c */; };
-		CB736FD41D9B6F0E00E3230F /* NSError+SimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB736FA71D9B6F0E00E3230F /* NSError+SimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CB736FD51D9B6F0E00E3230F /* NSError+SimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB736FA81D9B6F0E00E3230F /* NSError+SimpleConstructor.m */; };
+		CB736FD41D9B6F0E00E3230F /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB736FA71D9B6F0E00E3230F /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CB736FD51D9B6F0E00E3230F /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB736FA81D9B6F0E00E3230F /* NSError+KSCrashSimpleConstructor.m */; };
 		CB736FE21D9B6F4D00E3230F /* None.h in Headers */ = {isa = PBXBuildFile; fileRef = CB736FDF1D9B6F4D00E3230F /* None.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB736FE31D9B6F4D00E3230F /* Optional.h in Headers */ = {isa = PBXBuildFile; fileRef = CB736FE01D9B6F4D00E3230F /* Optional.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB736FE41D9B6F4D00E3230F /* StringRef.h in Headers */ = {isa = PBXBuildFile; fileRef = CB736FE11D9B6F4D00E3230F /* StringRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -271,8 +271,8 @@
 		CB736FA21D9B6F0E00E3230F /* KSSysCtl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSSysCtl.h; path = ../../Source/KSCrash/Recording/Tools/KSSysCtl.h; sourceTree = "<group>"; };
 		CB736FA31D9B6F0E00E3230F /* KSCrashMonitor_Zombie.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashMonitor_Zombie.h; path = ../../Source/KSCrash/Recording/Monitors/KSCrashMonitor_Zombie.h; sourceTree = "<group>"; };
 		CB736FA41D9B6F0E00E3230F /* KSCrashMonitor_Zombie.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = KSCrashMonitor_Zombie.c; path = ../../Source/KSCrash/Recording/Monitors/KSCrashMonitor_Zombie.c; sourceTree = "<group>"; };
-		CB736FA71D9B6F0E00E3230F /* NSError+SimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+SimpleConstructor.h"; path = "../../Source/KSCrash/Recording/Tools/NSError+SimpleConstructor.h"; sourceTree = "<group>"; };
-		CB736FA81D9B6F0E00E3230F /* NSError+SimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+SimpleConstructor.m"; path = "../../Source/KSCrash/Recording/Tools/NSError+SimpleConstructor.m"; sourceTree = "<group>"; };
+		CB736FA71D9B6F0E00E3230F /* NSError+KSCrashSimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+KSCrashSimpleConstructor.h"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.h"; sourceTree = "<group>"; };
+		CB736FA81D9B6F0E00E3230F /* NSError+KSCrashSimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+KSCrashSimpleConstructor.m"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.m"; sourceTree = "<group>"; };
 		CB736FDF1D9B6F4D00E3230F /* None.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = None.h; path = ../../Source/KSCrash/llvm/ADT/None.h; sourceTree = "<group>"; };
 		CB736FE01D9B6F4D00E3230F /* Optional.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Optional.h; path = ../../Source/KSCrash/llvm/ADT/Optional.h; sourceTree = "<group>"; };
 		CB736FE11D9B6F4D00E3230F /* StringRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StringRef.h; path = ../../Source/KSCrash/llvm/ADT/StringRef.h; sourceTree = "<group>"; };
@@ -537,8 +537,8 @@
 				CB736FA21D9B6F0E00E3230F /* KSSysCtl.h */,
 				CB25A5E91DF2372E00EC2B02 /* KSThread.c */,
 				CB25A5EA1DF2372E00EC2B02 /* KSThread.h */,
-				CB736FA71D9B6F0E00E3230F /* NSError+SimpleConstructor.h */,
-				CB736FA81D9B6F0E00E3230F /* NSError+SimpleConstructor.m */,
+				CB736FA71D9B6F0E00E3230F /* NSError+KSCrashSimpleConstructor.h */,
+				CB736FA81D9B6F0E00E3230F /* NSError+KSCrashSimpleConstructor.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -765,7 +765,7 @@
 				CB69B8CE1DC043B4002713B1 /* KSDate.h in Headers */,
 				CB736FB41D9B6F0E00E3230F /* KSDynamicLinker.h in Headers */,
 				CB9821BD1DFA15FA00164220 /* KSMachineContext_Apple.h in Headers */,
-				CB736FD41D9B6F0E00E3230F /* NSError+SimpleConstructor.h in Headers */,
+				CB736FD41D9B6F0E00E3230F /* NSError+KSCrashSimpleConstructor.h in Headers */,
 				CB7370721D9B6FE500E3230F /* KSCrashInstallationConsole.h in Headers */,
 				CB7370411D9B6FC800E3230F /* KSCrashReportSinkStandard.h in Headers */,
 				CB736F4E1D9B6ECD00E3230F /* KSCrashDoctor.h in Headers */,
@@ -911,7 +911,7 @@
 				CB7370711D9B6FE500E3230F /* KSCrashInstallation+Alert.m in Sources */,
 				CB25A6031DF23B8100EC2B02 /* KSDebug.c in Sources */,
 				CB7370301D9B6FB900E3230F /* NSData+GZip.m in Sources */,
-				CB736FD51D9B6F0E00E3230F /* NSError+SimpleConstructor.m in Sources */,
+				CB736FD51D9B6F0E00E3230F /* NSError+KSCrashSimpleConstructor.m in Sources */,
 				CB7370441D9B6FC800E3230F /* KSCrashReportSinkVictory.m in Sources */,
 				CB736FB71D9B6F0E00E3230F /* KSJSONCodec.c in Sources */,
 				CB736F7A1D9B6EF500E3230F /* KSCrashMonitor_NSException.m in Sources */,

--- a/WatchOS/KSCrash.xcodeproj/project.pbxproj
+++ b/WatchOS/KSCrash.xcodeproj/project.pbxproj
@@ -146,8 +146,8 @@
 		CB7370541D9B6FD000E3230F /* KSHTTPMultipartPostBody.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7370481D9B6FD000E3230F /* KSHTTPMultipartPostBody.m */; };
 		CB7370551D9B6FD000E3230F /* KSHTTPRequestSender.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7370491D9B6FD000E3230F /* KSHTTPRequestSender.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB7370561D9B6FD000E3230F /* KSHTTPRequestSender.m in Sources */ = {isa = PBXBuildFile; fileRef = CB73704A1D9B6FD000E3230F /* KSHTTPRequestSender.m */; };
-		CB7370591D9B6FD000E3230F /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CB73704D1D9B6FD000E3230F /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CB73705A1D9B6FD000E3230F /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CB73704E1D9B6FD000E3230F /* NSMutableData+AppendUTF8.m */; };
+		CB7370591D9B6FD000E3230F /* NSMutableData+KSCrashAppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CB73704D1D9B6FD000E3230F /* NSMutableData+KSCrashAppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CB73705A1D9B6FD000E3230F /* NSMutableData+KSCrashAppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CB73704E1D9B6FD000E3230F /* NSMutableData+KSCrashAppendUTF8.m */; };
 		CB73705B1D9B6FD000E3230F /* NSString+KSCrashURLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CB73704F1D9B6FD000E3230F /* NSString+KSCrashURLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB73705C1D9B6FD000E3230F /* NSString+KSCrashURLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7370501D9B6FD000E3230F /* NSString+KSCrashURLEncode.m */; };
 		CB73706D1D9B6FE500E3230F /* KSCrashInstallation+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB73705E1D9B6FE500E3230F /* KSCrashInstallation+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -328,8 +328,8 @@
 		CB73704A1D9B6FD000E3230F /* KSHTTPRequestSender.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSHTTPRequestSender.m; path = ../../Source/KSCrash/Reporting/Tools/KSHTTPRequestSender.m; sourceTree = "<group>"; };
 		CB73704B1D9B6FD000E3230F /* KSReachabilityKSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSReachabilityKSCrash.h; path = ../../Source/KSCrash/Reporting/Tools/KSReachabilityKSCrash.h; sourceTree = "<group>"; };
 		CB73704C1D9B6FD000E3230F /* KSReachabilityKSCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSReachabilityKSCrash.m; path = ../../Source/KSCrash/Reporting/Tools/KSReachabilityKSCrash.m; sourceTree = "<group>"; };
-		CB73704D1D9B6FD000E3230F /* NSMutableData+AppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableData+AppendUTF8.h"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.h"; sourceTree = "<group>"; };
-		CB73704E1D9B6FD000E3230F /* NSMutableData+AppendUTF8.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+AppendUTF8.m"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.m"; sourceTree = "<group>"; };
+		CB73704D1D9B6FD000E3230F /* NSMutableData+KSCrashAppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableData+KSCrashAppendUTF8.h"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+KSCrashAppendUTF8.h"; sourceTree = "<group>"; };
+		CB73704E1D9B6FD000E3230F /* NSMutableData+KSCrashAppendUTF8.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+KSCrashAppendUTF8.m"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+KSCrashAppendUTF8.m"; sourceTree = "<group>"; };
 		CB73704F1D9B6FD000E3230F /* NSString+KSCrashURLEncode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+KSCrashURLEncode.h"; path = "../../Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.h"; sourceTree = "<group>"; };
 		CB7370501D9B6FD000E3230F /* NSString+KSCrashURLEncode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+KSCrashURLEncode.m"; path = "../../Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.m"; sourceTree = "<group>"; };
 		CB73705E1D9B6FE500E3230F /* KSCrashInstallation+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "KSCrashInstallation+Private.h"; path = "../../Source/KSCrash/Installations/KSCrashInstallation+Private.h"; sourceTree = "<group>"; };
@@ -667,8 +667,8 @@
 				CB73704A1D9B6FD000E3230F /* KSHTTPRequestSender.m */,
 				CB73704B1D9B6FD000E3230F /* KSReachabilityKSCrash.h */,
 				CB73704C1D9B6FD000E3230F /* KSReachabilityKSCrash.m */,
-				CB73704D1D9B6FD000E3230F /* NSMutableData+AppendUTF8.h */,
-				CB73704E1D9B6FD000E3230F /* NSMutableData+AppendUTF8.m */,
+				CB73704D1D9B6FD000E3230F /* NSMutableData+KSCrashAppendUTF8.h */,
+				CB73704E1D9B6FD000E3230F /* NSMutableData+KSCrashAppendUTF8.m */,
 				CB73704F1D9B6FD000E3230F /* NSString+KSCrashURLEncode.h */,
 				CB7370501D9B6FD000E3230F /* NSString+KSCrashURLEncode.m */,
 			);
@@ -743,7 +743,7 @@
 				CB736FED1D9B6F5D00E3230F /* Compiler.h in Headers */,
 				CB736FEE1D9B6F5D00E3230F /* type_traits.h in Headers */,
 				CB73701A1D9B6FA800E3230F /* KSCrashReportFilterAppleFmt.h in Headers */,
-				CB7370591D9B6FD000E3230F /* NSMutableData+AppendUTF8.h in Headers */,
+				CB7370591D9B6FD000E3230F /* NSMutableData+KSCrashAppendUTF8.h in Headers */,
 				CB56580C1E1DD4D0005A8302 /* KSSymbolicator.h in Headers */,
 				CB736F561D9B6ECD00E3230F /* KSCrashReportWriter.h in Headers */,
 				CB736F5C1D9B6ECD00E3230F /* KSCrashMonitor_System.h in Headers */,
@@ -897,7 +897,7 @@
 				CB736FBA1D9B6F0E00E3230F /* KSJSONCodecObjC.m in Sources */,
 				CB736F7C1D9B6EF500E3230F /* KSCrashMonitor_Signal.c in Sources */,
 				CB736F341D9B6EAF00E3230F /* KSCrash.m in Sources */,
-				CB73705A1D9B6FD000E3230F /* NSMutableData+AppendUTF8.m in Sources */,
+				CB73705A1D9B6FD000E3230F /* NSMutableData+KSCrashAppendUTF8.m in Sources */,
 				CB73701F1D9B6FA800E3230F /* KSCrashReportFilterGZip.m in Sources */,
 				CBA1A5481DD25082007B1CE7 /* KSDemangle_CPP.cpp in Sources */,
 				CB7370211D9B6FA800E3230F /* KSCrashReportFilterJSON.m in Sources */,

--- a/WatchOS/KSCrash.xcodeproj/project.pbxproj
+++ b/WatchOS/KSCrash.xcodeproj/project.pbxproj
@@ -125,8 +125,8 @@
 		CB7370231D9B6FA800E3230F /* KSCrashReportFilterSets.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7370131D9B6FA800E3230F /* KSCrashReportFilterSets.m */; };
 		CB7370241D9B6FA800E3230F /* KSCrashReportFilterStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7370141D9B6FA800E3230F /* KSCrashReportFilterStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB7370251D9B6FA800E3230F /* KSCrashReportFilterStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7370151D9B6FA800E3230F /* KSCrashReportFilterStringify.m */; };
-		CB73702C1D9B6FB900E3230F /* Container+DeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7370271D9B6FB900E3230F /* Container+DeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CB73702D1D9B6FB900E3230F /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7370281D9B6FB900E3230F /* Container+DeepSearch.m */; };
+		CB73702C1D9B6FB900E3230F /* Container+KSCrashDeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7370271D9B6FB900E3230F /* Container+KSCrashDeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CB73702D1D9B6FB900E3230F /* Container+KSCrashDeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7370281D9B6FB900E3230F /* Container+KSCrashDeepSearch.m */; };
 		CB73702E1D9B6FB900E3230F /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7370291D9B6FB900E3230F /* KSVarArgs.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB73702F1D9B6FB900E3230F /* NSData+KSCrashGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CB73702A1D9B6FB900E3230F /* NSData+KSCrashGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB7370301D9B6FB900E3230F /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CB73702B1D9B6FB900E3230F /* NSData+KSCrashGZip.m */; };
@@ -305,8 +305,8 @@
 		CB7370131D9B6FA800E3230F /* KSCrashReportFilterSets.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashReportFilterSets.m; path = ../../Source/KSCrash/Reporting/Filters/KSCrashReportFilterSets.m; sourceTree = "<group>"; };
 		CB7370141D9B6FA800E3230F /* KSCrashReportFilterStringify.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashReportFilterStringify.h; path = ../../Source/KSCrash/Reporting/Filters/KSCrashReportFilterStringify.h; sourceTree = "<group>"; };
 		CB7370151D9B6FA800E3230F /* KSCrashReportFilterStringify.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashReportFilterStringify.m; path = ../../Source/KSCrash/Reporting/Filters/KSCrashReportFilterStringify.m; sourceTree = "<group>"; };
-		CB7370271D9B6FB900E3230F /* Container+DeepSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Container+DeepSearch.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+DeepSearch.h"; sourceTree = "<group>"; };
-		CB7370281D9B6FB900E3230F /* Container+DeepSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+DeepSearch.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+DeepSearch.m"; sourceTree = "<group>"; };
+		CB7370271D9B6FB900E3230F /* Container+KSCrashDeepSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Container+KSCrashDeepSearch.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+KSCrashDeepSearch.h"; sourceTree = "<group>"; };
+		CB7370281D9B6FB900E3230F /* Container+KSCrashDeepSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+KSCrashDeepSearch.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+KSCrashDeepSearch.m"; sourceTree = "<group>"; };
 		CB7370291D9B6FB900E3230F /* KSVarArgs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSVarArgs.h; path = ../../Source/KSCrash/Reporting/Filters/Tools/KSVarArgs.h; sourceTree = "<group>"; };
 		CB73702A1D9B6FB900E3230F /* NSData+KSCrashGZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+KSCrashGZip.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.h"; sourceTree = "<group>"; };
 		CB73702B1D9B6FB900E3230F /* NSData+KSCrashGZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+KSCrashGZip.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.m"; sourceTree = "<group>"; };
@@ -678,8 +678,8 @@
 		CB7370261D9B6FB000E3230F /* Tools */ = {
 			isa = PBXGroup;
 			children = (
-				CB7370271D9B6FB900E3230F /* Container+DeepSearch.h */,
-				CB7370281D9B6FB900E3230F /* Container+DeepSearch.m */,
+				CB7370271D9B6FB900E3230F /* Container+KSCrashDeepSearch.h */,
+				CB7370281D9B6FB900E3230F /* Container+KSCrashDeepSearch.m */,
 				CB7370291D9B6FB900E3230F /* KSVarArgs.h */,
 				CB73702A1D9B6FB900E3230F /* NSData+KSCrashGZip.h */,
 				CB73702B1D9B6FB900E3230F /* NSData+KSCrashGZip.m */,
@@ -802,7 +802,7 @@
 				CB736FE41D9B6F4D00E3230F /* StringRef.h in Headers */,
 				CB7370221D9B6FA800E3230F /* KSCrashReportFilterSets.h in Headers */,
 				CB736F551D9B6ECD00E3230F /* KSCrashReportVersion.h in Headers */,
-				CB73702C1D9B6FB900E3230F /* Container+DeepSearch.h in Headers */,
+				CB73702C1D9B6FB900E3230F /* Container+KSCrashDeepSearch.h in Headers */,
 				CB28510C1E02174B00C90D80 /* KSID.h in Headers */,
 				CB736FCA1D9B6F0E00E3230F /* KSSignalInfo.h in Headers */,
 				CB73706E1D9B6FE500E3230F /* KSCrashInstallation.h in Headers */,
@@ -939,7 +939,7 @@
 				CBA8A0D91E25D3CF0019B5B9 /* KSCrashCachedData.c in Sources */,
 				CB7370731D9B6FE500E3230F /* KSCrashInstallationConsole.m in Sources */,
 				CB28510B1E02174B00C90D80 /* KSID.c in Sources */,
-				CB73702D1D9B6FB900E3230F /* Container+DeepSearch.m in Sources */,
+				CB73702D1D9B6FB900E3230F /* Container+KSCrashDeepSearch.m in Sources */,
 				CB7370421D9B6FC800E3230F /* KSCrashReportSinkStandard.m in Sources */,
 				CB7370771D9B6FE500E3230F /* KSCrashInstallationQuincyHockey.m in Sources */,
 				CB736FB31D9B6F0E00E3230F /* KSDynamicLinker.c in Sources */,

--- a/WatchOS/KSCrash.xcodeproj/project.pbxproj
+++ b/WatchOS/KSCrash.xcodeproj/project.pbxproj
@@ -128,8 +128,8 @@
 		CB73702C1D9B6FB900E3230F /* Container+DeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7370271D9B6FB900E3230F /* Container+DeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB73702D1D9B6FB900E3230F /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7370281D9B6FB900E3230F /* Container+DeepSearch.m */; };
 		CB73702E1D9B6FB900E3230F /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7370291D9B6FB900E3230F /* KSVarArgs.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CB73702F1D9B6FB900E3230F /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CB73702A1D9B6FB900E3230F /* NSData+GZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CB7370301D9B6FB900E3230F /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CB73702B1D9B6FB900E3230F /* NSData+GZip.m */; };
+		CB73702F1D9B6FB900E3230F /* NSData+KSCrashGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CB73702A1D9B6FB900E3230F /* NSData+KSCrashGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB7370301D9B6FB900E3230F /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CB73702B1D9B6FB900E3230F /* NSData+KSCrashGZip.m */; };
 		CB73703B1D9B6FC800E3230F /* KSCrashReportSinkConsole.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7370311D9B6FC800E3230F /* KSCrashReportSinkConsole.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB73703C1D9B6FC800E3230F /* KSCrashReportSinkConsole.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7370321D9B6FC800E3230F /* KSCrashReportSinkConsole.m */; };
 		CB73703D1D9B6FC800E3230F /* KSCrashReportSinkEMail.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7370331D9B6FC800E3230F /* KSCrashReportSinkEMail.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -308,8 +308,8 @@
 		CB7370271D9B6FB900E3230F /* Container+DeepSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Container+DeepSearch.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+DeepSearch.h"; sourceTree = "<group>"; };
 		CB7370281D9B6FB900E3230F /* Container+DeepSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+DeepSearch.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+DeepSearch.m"; sourceTree = "<group>"; };
 		CB7370291D9B6FB900E3230F /* KSVarArgs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSVarArgs.h; path = ../../Source/KSCrash/Reporting/Filters/Tools/KSVarArgs.h; sourceTree = "<group>"; };
-		CB73702A1D9B6FB900E3230F /* NSData+GZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+GZip.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.h"; sourceTree = "<group>"; };
-		CB73702B1D9B6FB900E3230F /* NSData+GZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+GZip.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.m"; sourceTree = "<group>"; };
+		CB73702A1D9B6FB900E3230F /* NSData+KSCrashGZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+KSCrashGZip.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.h"; sourceTree = "<group>"; };
+		CB73702B1D9B6FB900E3230F /* NSData+KSCrashGZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+KSCrashGZip.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.m"; sourceTree = "<group>"; };
 		CB7370311D9B6FC800E3230F /* KSCrashReportSinkConsole.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashReportSinkConsole.h; path = ../../Source/KSCrash/Reporting/Sinks/KSCrashReportSinkConsole.h; sourceTree = "<group>"; };
 		CB7370321D9B6FC800E3230F /* KSCrashReportSinkConsole.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashReportSinkConsole.m; path = ../../Source/KSCrash/Reporting/Sinks/KSCrashReportSinkConsole.m; sourceTree = "<group>"; };
 		CB7370331D9B6FC800E3230F /* KSCrashReportSinkEMail.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashReportSinkEMail.h; path = ../../Source/KSCrash/Reporting/Sinks/KSCrashReportSinkEMail.h; sourceTree = "<group>"; };
@@ -681,8 +681,8 @@
 				CB7370271D9B6FB900E3230F /* Container+DeepSearch.h */,
 				CB7370281D9B6FB900E3230F /* Container+DeepSearch.m */,
 				CB7370291D9B6FB900E3230F /* KSVarArgs.h */,
-				CB73702A1D9B6FB900E3230F /* NSData+GZip.h */,
-				CB73702B1D9B6FB900E3230F /* NSData+GZip.m */,
+				CB73702A1D9B6FB900E3230F /* NSData+KSCrashGZip.h */,
+				CB73702B1D9B6FB900E3230F /* NSData+KSCrashGZip.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -731,7 +731,7 @@
 				CB1F3DDC1DB046CB007F240B /* KSCrashAblyForkFramework.h in Headers */,
 				CB9BFDD31DD53FF300EA4F27 /* KSCrashMonitorContext.h in Headers */,
 				CB1806851E0DA02800239506 /* KSStackCursor_Backtrace.h in Headers */,
-				CB73702F1D9B6FB900E3230F /* NSData+GZip.h in Headers */,
+				CB73702F1D9B6FB900E3230F /* NSData+KSCrashGZip.h in Headers */,
 				CB73701E1D9B6FA800E3230F /* KSCrashReportFilterGZip.h in Headers */,
 				CB736F7F1D9B6EF500E3230F /* KSCrashMonitor_User.h in Headers */,
 				CB736F331D9B6EAF00E3230F /* KSCrash.h in Headers */,
@@ -910,7 +910,7 @@
 				CB56580B1E1DD4D0005A8302 /* KSSymbolicator.c in Sources */,
 				CB7370711D9B6FE500E3230F /* KSCrashInstallation+Alert.m in Sources */,
 				CB25A6031DF23B8100EC2B02 /* KSDebug.c in Sources */,
-				CB7370301D9B6FB900E3230F /* NSData+GZip.m in Sources */,
+				CB7370301D9B6FB900E3230F /* NSData+KSCrashGZip.m in Sources */,
 				CB736FD51D9B6F0E00E3230F /* NSError+KSCrashSimpleConstructor.m in Sources */,
 				CB7370441D9B6FC800E3230F /* KSCrashReportSinkVictory.m in Sources */,
 				CB736FB71D9B6F0E00E3230F /* KSJSONCodec.c in Sources */,

--- a/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
+++ b/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
@@ -117,8 +117,8 @@
 		03DE7CC21C84DFC100F789BA /* KSHTTPRequestSender.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D6817EB765C0056DA83 /* KSHTTPRequestSender.m */; };
 		03DE7CC31C84DFC100F789BA /* KSReachabilityKSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D7817EB765C0056DA83 /* KSReachabilityKSCrash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		03DE7CC41C84DFC100F789BA /* KSReachabilityKSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D7917EB765C0056DA83 /* KSReachabilityKSCrash.m */; };
-		03DE7CC51C84DFC100F789BA /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		03DE7CC61C84DFC100F789BA /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D9017EB765C0056DA83 /* NSMutableData+AppendUTF8.m */; };
+		03DE7CC51C84DFC100F789BA /* NSMutableData+KSCrashAppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		03DE7CC61C84DFC100F789BA /* NSMutableData+KSCrashAppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D9017EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.m */; };
 		03DE7CC71C84DFCD00F789BA /* KSCrashInstallation+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2717EB765C0056DA83 /* KSCrashInstallation+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03DE7CC81C84DFCD00F789BA /* KSCrashInstallation.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2517EB765C0056DA83 /* KSCrashInstallation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03DE7CC91C84DFCD00F789BA /* KSCrashInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D2617EB765C0056DA83 /* KSCrashInstallation.m */; };
@@ -220,7 +220,7 @@
 		632D8DFF1EDFFA6700A9A62E /* KSHTTPMultipartPostBody.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D6517EB765C0056DA83 /* KSHTTPMultipartPostBody.h */; };
 		632D8E001EDFFA6700A9A62E /* KSHTTPRequestSender.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D6717EB765C0056DA83 /* KSHTTPRequestSender.h */; };
 		632D8E011EDFFA6700A9A62E /* KSReachabilityKSCrash.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D7817EB765C0056DA83 /* KSReachabilityKSCrash.h */; };
-		632D8E021EDFFA6700A9A62E /* NSMutableData+AppendUTF8.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */; };
+		632D8E021EDFFA6700A9A62E /* NSMutableData+KSCrashAppendUTF8.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.h */; };
 		632D8E031EDFFA6700A9A62E /* NSString+KSCrashURLEncode.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC01CBC197D005EAF61 /* NSString+KSCrashURLEncode.h */; };
 		632D8E041EDFFA6700A9A62E /* KSCrashInstallation.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2517EB765C0056DA83 /* KSCrashInstallation.h */; };
 		632D8E051EDFFA6700A9A62E /* KSCrashInstallation+Alert.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CB8F1DC41CCADB2A0022CDF0 /* KSCrashInstallation+Alert.h */; };
@@ -262,7 +262,7 @@
 		CB0264C417FA5B13003E0AED /* KSSysCtl_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB02649F17FA5B13003E0AED /* KSSysCtl_Tests.m */; };
 		CB0264C717FA5B13003E0AED /* NSData+Gzip_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0264A217FA5B13003E0AED /* NSData+Gzip_Tests.m */; };
 		CB0264C917FA5B13003E0AED /* NSError+KSCrashSimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0264A417FA5B13003E0AED /* NSError+KSCrashSimpleConstructor_Tests.m */; };
-		CB0264CA17FA5B13003E0AED /* NSMutableData+AppendUTF8_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0264A517FA5B13003E0AED /* NSMutableData+AppendUTF8_Tests.m */; };
+		CB0264CA17FA5B13003E0AED /* NSMutableData+KSCrashAppendUTF8_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0264A517FA5B13003E0AED /* NSMutableData+KSCrashAppendUTF8_Tests.m */; };
 		CB0264CB17FA5B13003E0AED /* RFC3339UTFString_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0264A617FA5B13003E0AED /* RFC3339UTFString_Tests.m */; };
 		CB0264CC17FA5B13003E0AED /* XCTestCase+KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0264A817FA5B13003E0AED /* XCTestCase+KSCrash.m */; };
 		CB0264CE17FA60C9003E0AED /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB0264CD17FA60C9003E0AED /* SystemConfiguration.framework */; };
@@ -483,7 +483,7 @@
 		CBF53E3E17EB765C0056DA83 /* KSCrashMonitor_Zombie.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8817EB765C0056DA83 /* KSCrashMonitor_Zombie.c */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		CBF53E4117EB765C0056DA83 /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+KSCrashGZip.m */; };
 		CBF53E4717EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8E17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m */; };
-		CBF53E4A17EB765C0056DA83 /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D9017EB765C0056DA83 /* NSMutableData+AppendUTF8.m */; };
+		CBF53E4A17EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D9017EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.m */; };
 		CBF53E5617EB7EA80056DA83 /* KSCrashC.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1F17EB765C0056DA83 /* KSCrashC.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBF53E5817EB7EA80056DA83 /* KSCrashReport.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D3117EB765C0056DA83 /* KSCrashReport.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E5917EB7EA80056DA83 /* KSCrashReportFields.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D3217EB765C0056DA83 /* KSCrashReportFields.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -529,7 +529,7 @@
 		CBF53E8E17EB7EA80056DA83 /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8617EB765C0056DA83 /* KSVarArgs.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E8F17EB7EA80056DA83 /* NSData+KSCrashGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+KSCrashGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBF53E9117EB7EA80056DA83 /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8D17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBF53E9217EB7EA80056DA83 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBF53E9217EB7EA80056DA83 /* NSMutableData+KSCrashAppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E9317EB7EA80056DA83 /* KSCrashInstallation+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2717EB765C0056DA83 /* KSCrashInstallation+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBF53E9417EB7EA80056DA83 /* KSCrashInstallation.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2517EB765C0056DA83 /* KSCrashInstallation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBF53E9517EB7EA80056DA83 /* KSCrashInstallationEmail.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2817EB765C0056DA83 /* KSCrashInstallationEmail.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -589,7 +589,7 @@
 		EDF2BEB21CCF15AD004BADF4 /* KSCrashInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D2617EB765C0056DA83 /* KSCrashInstallation.m */; };
 		EDF2BEB31CCF15AD004BADF4 /* KSSignalInfo.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D7C17EB765C0056DA83 /* KSSignalInfo.c */; };
 		EDF2BEB41CCF15AD004BADF4 /* KSCrashMonitor_AppState.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D5D17EB765C0056DA83 /* KSCrashMonitor_AppState.c */; };
-		EDF2BEB51CCF15AD004BADF4 /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D9017EB765C0056DA83 /* NSMutableData+AppendUTF8.m */; };
+		EDF2BEB51CCF15AD004BADF4 /* NSMutableData+KSCrashAppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D9017EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.m */; };
 		EDF2BEB61CCF15AD004BADF4 /* KSCrashMonitorType.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D5F17EB765C0056DA83 /* KSCrashMonitorType.c */; };
 		EDF2BEB71CCF15AD004BADF4 /* KSCrashReportFilterAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D3617EB765C0056DA83 /* KSCrashReportFilterAlert.m */; };
 		EDF2BEB81CCF15AD004BADF4 /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1417EB765C0056DA83 /* Container+DeepSearch.m */; };
@@ -637,7 +637,7 @@
 		EDF2BEEC1CCF15AD004BADF4 /* NSData+KSCrashGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+KSCrashGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EDF2BEED1CCF15AD004BADF4 /* KSCrashMonitor_User.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D5A17EB765C0056DA83 /* KSCrashMonitor_User.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEEE1CCF15AD004BADF4 /* StringRef.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC43F0B1C5AF2B10083A11B /* StringRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EDF2BEEF1CCF15AD004BADF4 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EDF2BEEF1CCF15AD004BADF4 /* NSMutableData+KSCrashAppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEF01CCF15AD004BADF4 /* KSCrashMonitor_CPPException.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D4E17EB765C0056DA83 /* KSCrashMonitor_CPPException.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEF11CCF15AD004BADF4 /* KSCrashDoctor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2317EB765C0056DA83 /* KSCrashDoctor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEF21CCF15AD004BADF4 /* KSCrashInstallationConsole.h in Headers */ = {isa = PBXBuildFile; fileRef = CB94D35B1CAC11B000806679 /* KSCrashInstallationConsole.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -779,7 +779,7 @@
 				632D8DFF1EDFFA6700A9A62E /* KSHTTPMultipartPostBody.h in Copy Headers */,
 				632D8E001EDFFA6700A9A62E /* KSHTTPRequestSender.h in Copy Headers */,
 				632D8E011EDFFA6700A9A62E /* KSReachabilityKSCrash.h in Copy Headers */,
-				632D8E021EDFFA6700A9A62E /* NSMutableData+AppendUTF8.h in Copy Headers */,
+				632D8E021EDFFA6700A9A62E /* NSMutableData+KSCrashAppendUTF8.h in Copy Headers */,
 				632D8E031EDFFA6700A9A62E /* NSString+KSCrashURLEncode.h in Copy Headers */,
 				632D8E041EDFFA6700A9A62E /* KSCrashInstallation.h in Copy Headers */,
 				632D8E051EDFFA6700A9A62E /* KSCrashInstallation+Alert.h in Copy Headers */,
@@ -833,7 +833,7 @@
 		CB0264A117FA5B13003E0AED /* KSCrashMonitor_Zombie_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashMonitor_Zombie_Tests.m; path = "../../Source/KSCrash-Tests/KSCrashMonitor_Zombie_Tests.m"; sourceTree = "<group>"; };
 		CB0264A217FA5B13003E0AED /* NSData+Gzip_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+Gzip_Tests.m"; path = "../../Source/KSCrash-Tests/NSData+Gzip_Tests.m"; sourceTree = "<group>"; };
 		CB0264A417FA5B13003E0AED /* NSError+KSCrashSimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+KSCrashSimpleConstructor_Tests.m"; path = "../../Source/KSCrash-Tests/NSError+KSCrashSimpleConstructor_Tests.m"; sourceTree = "<group>"; };
-		CB0264A517FA5B13003E0AED /* NSMutableData+AppendUTF8_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+AppendUTF8_Tests.m"; path = "../../Source/KSCrash-Tests/NSMutableData+AppendUTF8_Tests.m"; sourceTree = "<group>"; };
+		CB0264A517FA5B13003E0AED /* NSMutableData+KSCrashAppendUTF8_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+KSCrashAppendUTF8_Tests.m"; path = "../../Source/KSCrash-Tests/NSMutableData+KSCrashAppendUTF8_Tests.m"; sourceTree = "<group>"; };
 		CB0264A617FA5B13003E0AED /* RFC3339UTFString_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RFC3339UTFString_Tests.m; path = "../../Source/KSCrash-Tests/RFC3339UTFString_Tests.m"; sourceTree = "<group>"; };
 		CB0264A717FA5B13003E0AED /* XCTestCase+KSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+KSCrash.h"; path = "../../Source/KSCrash-Tests/XCTestCase+KSCrash.h"; sourceTree = "<group>"; };
 		CB0264A817FA5B13003E0AED /* XCTestCase+KSCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+KSCrash.m"; path = "../../Source/KSCrash-Tests/XCTestCase+KSCrash.m"; sourceTree = "<group>"; };
@@ -1030,8 +1030,8 @@
 		CBF53D8A17EB765C0056DA83 /* NSData+KSCrashGZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+KSCrashGZip.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.m"; sourceTree = "<group>"; };
 		CBF53D8D17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+KSCrashSimpleConstructor.h"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.h"; sourceTree = "<group>"; };
 		CBF53D8E17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+KSCrashSimpleConstructor.m"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.m"; sourceTree = "<group>"; };
-		CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableData+AppendUTF8.h"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.h"; sourceTree = "<group>"; };
-		CBF53D9017EB765C0056DA83 /* NSMutableData+AppendUTF8.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+AppendUTF8.m"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.m"; sourceTree = "<group>"; };
+		CBF53D8F17EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableData+KSCrashAppendUTF8.h"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+KSCrashAppendUTF8.h"; sourceTree = "<group>"; };
+		CBF53D9017EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+KSCrashAppendUTF8.m"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+KSCrashAppendUTF8.m"; sourceTree = "<group>"; };
 		DCA19E2B18817AD100DCA792 /* KSCrashReportFilterAlert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashReportFilterAlert.h; path = ../../Source/KSCrash/Reporting/Filters/KSCrashReportFilterAlert.h; sourceTree = "<group>"; };
 		DCA19E2E18817BA200DCA792 /* KSCrashReportFilterSets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashReportFilterSets.h; path = ../../Source/KSCrash/Reporting/Filters/KSCrashReportFilterSets.h; sourceTree = "<group>"; };
 		EDF2BF211CCF15AD004BADF4 /* KSCrash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KSCrash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1186,7 +1186,7 @@
 				CB25A5DD1DF231E600EC2B02 /* KSThread_Tests.m */,
 				CB0264A217FA5B13003E0AED /* NSData+Gzip_Tests.m */,
 				CB0264A417FA5B13003E0AED /* NSError+KSCrashSimpleConstructor_Tests.m */,
-				CB0264A517FA5B13003E0AED /* NSMutableData+AppendUTF8_Tests.m */,
+				CB0264A517FA5B13003E0AED /* NSMutableData+KSCrashAppendUTF8_Tests.m */,
 				CB0264A617FA5B13003E0AED /* RFC3339UTFString_Tests.m */,
 				CB6D131517EB743A00BC2C04 /* Supporting Files */,
 				CB25A5CD1DF229F100EC2B02 /* TestThread.h */,
@@ -1445,8 +1445,8 @@
 				CBF53D6817EB765C0056DA83 /* KSHTTPRequestSender.m */,
 				CBF53D7817EB765C0056DA83 /* KSReachabilityKSCrash.h */,
 				CBF53D7917EB765C0056DA83 /* KSReachabilityKSCrash.m */,
-				CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */,
-				CBF53D9017EB765C0056DA83 /* NSMutableData+AppendUTF8.m */,
+				CBF53D8F17EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.h */,
+				CBF53D9017EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.m */,
 				CBEE5DC01CBC197D005EAF61 /* NSString+KSCrashURLEncode.h */,
 				CBEE5DC11CBC197D005EAF61 /* NSString+KSCrashURLEncode.m */,
 			);
@@ -1565,7 +1565,7 @@
 				03DE7C611C84DF8600F789BA /* KSCrashMonitor_User.h in Headers */,
 				CB5657DF1E1CB8CE005A8302 /* KSSymbolicator.h in Headers */,
 				03DE7C641C84DF9200F789BA /* StringRef.h in Headers */,
-				03DE7CC51C84DFC100F789BA /* NSMutableData+AppendUTF8.h in Headers */,
+				03DE7CC51C84DFC100F789BA /* NSMutableData+KSCrashAppendUTF8.h in Headers */,
 				CB25A6161DF25EF100EC2B02 /* KSMachineContext.h in Headers */,
 				CB25A61A1DF278D900EC2B02 /* KSMachineContext_Apple.h in Headers */,
 				03DE7C551C84DF8600F789BA /* KSCrashMonitor_CPPException.h in Headers */,
@@ -1662,7 +1662,7 @@
 				CBF53E6117EB7EA80056DA83 /* KSCrashMonitor_Deadlock.h in Headers */,
 				CBF53E9117EB7EA80056DA83 /* NSError+KSCrashSimpleConstructor.h in Headers */,
 				CB69B8C81DC03FFF002713B1 /* KSDate.h in Headers */,
-				CBF53E9217EB7EA80056DA83 /* NSMutableData+AppendUTF8.h in Headers */,
+				CBF53E9217EB7EA80056DA83 /* NSMutableData+KSCrashAppendUTF8.h in Headers */,
 				CB0C19C21DD0F2EE005B2F80 /* KSCrashReportFixer.h in Headers */,
 				CB25A6061DF23D7300EC2B02 /* KSCPU_Apple.h in Headers */,
 				CBF53E6017EB7EA80056DA83 /* KSCrashMonitor_CPPException.h in Headers */,
@@ -1769,7 +1769,7 @@
 				EDF2BEEC1CCF15AD004BADF4 /* NSData+KSCrashGZip.h in Headers */,
 				EDF2BEED1CCF15AD004BADF4 /* KSCrashMonitor_User.h in Headers */,
 				EDF2BEEE1CCF15AD004BADF4 /* StringRef.h in Headers */,
-				EDF2BEEF1CCF15AD004BADF4 /* NSMutableData+AppendUTF8.h in Headers */,
+				EDF2BEEF1CCF15AD004BADF4 /* NSMutableData+KSCrashAppendUTF8.h in Headers */,
 				CB5657E01E1CB8CE005A8302 /* KSSymbolicator.h in Headers */,
 				EDF2BEF01CCF15AD004BADF4 /* KSCrashMonitor_CPPException.h in Headers */,
 				EDF2BEF11CCF15AD004BADF4 /* KSCrashDoctor.h in Headers */,
@@ -2027,7 +2027,7 @@
 				03DE7CC91C84DFCD00F789BA /* KSCrashInstallation.m in Sources */,
 				03DE7C8F1C84DFAB00F789BA /* KSSignalInfo.c in Sources */,
 				03DE7C481C84DF8100F789BA /* KSCrashMonitor_AppState.c in Sources */,
-				03DE7CC61C84DFC100F789BA /* NSMutableData+AppendUTF8.m in Sources */,
+				03DE7CC61C84DFC100F789BA /* NSMutableData+KSCrashAppendUTF8.m in Sources */,
 				03DE7C4A1C84DF8100F789BA /* KSCrashMonitorType.c in Sources */,
 				CB69B8DB1DC0ED80002713B1 /* KSLogger.c in Sources */,
 				CB69B8C61DC03FFF002713B1 /* KSDate.c in Sources */,
@@ -2108,7 +2108,7 @@
 				CBF53DF917EB765C0056DA83 /* KSCrashMonitor_User.c in Sources */,
 				CBF53DD117EB765C0056DA83 /* KSCrashReportFilterJSON.m in Sources */,
 				CBC43F3A1C5AF2B10083A11B /* Punycode.cpp in Sources */,
-				CBF53E4A17EB765C0056DA83 /* NSMutableData+AppendUTF8.m in Sources */,
+				CBF53E4A17EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.m in Sources */,
 				CBF53E4717EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m in Sources */,
 				CBF53DCB17EB765C0056DA83 /* KSCrashReportFilterBasic.m in Sources */,
 				CBF53E3E17EB765C0056DA83 /* KSCrashMonitor_Zombie.c in Sources */,
@@ -2132,7 +2132,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CB0264CA17FA5B13003E0AED /* NSMutableData+AppendUTF8_Tests.m in Sources */,
+				CB0264CA17FA5B13003E0AED /* NSMutableData+KSCrashAppendUTF8_Tests.m in Sources */,
 				CB0264B217FA5B13003E0AED /* KSCrashReportFilterGZip_Tests.m in Sources */,
 				CB0264CB17FA5B13003E0AED /* RFC3339UTFString_Tests.m in Sources */,
 				CB0264B517FA5B13003E0AED /* KSCrashMonitor_Deadlock_Tests.m in Sources */,
@@ -2239,7 +2239,7 @@
 				EDF2BEB21CCF15AD004BADF4 /* KSCrashInstallation.m in Sources */,
 				EDF2BEB31CCF15AD004BADF4 /* KSSignalInfo.c in Sources */,
 				EDF2BEB41CCF15AD004BADF4 /* KSCrashMonitor_AppState.c in Sources */,
-				EDF2BEB51CCF15AD004BADF4 /* NSMutableData+AppendUTF8.m in Sources */,
+				EDF2BEB51CCF15AD004BADF4 /* NSMutableData+KSCrashAppendUTF8.m in Sources */,
 				EDF2BEB61CCF15AD004BADF4 /* KSCrashMonitorType.c in Sources */,
 				CB69B8DC1DC0ED80002713B1 /* KSLogger.c in Sources */,
 				CB69B8C71DC03FFF002713B1 /* KSDate.c in Sources */,

--- a/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
+++ b/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
@@ -107,8 +107,8 @@
 		03DE7CB81C84DFBC00F789BA /* Container+DeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1317EB765C0056DA83 /* Container+DeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		03DE7CB91C84DFBC00F789BA /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1417EB765C0056DA83 /* Container+DeepSearch.m */; };
 		03DE7CBA1C84DFBC00F789BA /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8617EB765C0056DA83 /* KSVarArgs.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		03DE7CBB1C84DFBC00F789BA /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+GZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		03DE7CBC1C84DFBC00F789BA /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+GZip.m */; };
+		03DE7CBB1C84DFBC00F789BA /* NSData+KSCrashGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+KSCrashGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		03DE7CBC1C84DFBC00F789BA /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+KSCrashGZip.m */; };
 		03DE7CBD1C84DFC100F789BA /* KSCString.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D6117EB765C0056DA83 /* KSCString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		03DE7CBE1C84DFC100F789BA /* KSCString.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D6217EB765C0056DA83 /* KSCString.m */; };
 		03DE7CBF1C84DFC100F789BA /* KSHTTPMultipartPostBody.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D6517EB765C0056DA83 /* KSHTTPMultipartPostBody.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -210,7 +210,7 @@
 		632D8DF51EDFFA6700A9A62E /* KSCrashReportFilterStringify.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CB94D3611CAC190900806679 /* KSCrashReportFilterStringify.h */; };
 		632D8DF61EDFFA6700A9A62E /* Container+DeepSearch.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1317EB765C0056DA83 /* Container+DeepSearch.h */; };
 		632D8DF71EDFFA6700A9A62E /* KSVarArgs.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8617EB765C0056DA83 /* KSVarArgs.h */; };
-		632D8DF81EDFFA6700A9A62E /* NSData+GZip.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+GZip.h */; };
+		632D8DF81EDFFA6700A9A62E /* NSData+KSCrashGZip.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+KSCrashGZip.h */; };
 		632D8DF91EDFFA6700A9A62E /* KSCrashReportSinkConsole.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D4117EB765C0056DA83 /* KSCrashReportSinkConsole.h */; };
 		632D8DFA1EDFFA6700A9A62E /* KSCrashReportSinkEMail.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D4317EB765C0056DA83 /* KSCrashReportSinkEMail.h */; };
 		632D8DFB1EDFFA6700A9A62E /* KSCrashReportSinkQuincyHockey.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D4517EB765C0056DA83 /* KSCrashReportSinkQuincyHockey.h */; };
@@ -481,7 +481,7 @@
 		CBF53E3517EB765C0056DA83 /* KSSysCtl.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8117EB765C0056DA83 /* KSSysCtl.c */; };
 		CBF53E3917EB765C0056DA83 /* KSCrashMonitor_System.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8417EB765C0056DA83 /* KSCrashMonitor_System.m */; };
 		CBF53E3E17EB765C0056DA83 /* KSCrashMonitor_Zombie.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8817EB765C0056DA83 /* KSCrashMonitor_Zombie.c */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		CBF53E4117EB765C0056DA83 /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+GZip.m */; };
+		CBF53E4117EB765C0056DA83 /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+KSCrashGZip.m */; };
 		CBF53E4717EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8E17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m */; };
 		CBF53E4A17EB765C0056DA83 /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D9017EB765C0056DA83 /* NSMutableData+AppendUTF8.m */; };
 		CBF53E5617EB7EA80056DA83 /* KSCrashC.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1F17EB765C0056DA83 /* KSCrashC.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -527,7 +527,7 @@
 		CBF53E8B17EB7EA80056DA83 /* KSHTTPRequestSender.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D6717EB765C0056DA83 /* KSHTTPRequestSender.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E8C17EB7EA80056DA83 /* KSReachabilityKSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D7817EB765C0056DA83 /* KSReachabilityKSCrash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E8E17EB7EA80056DA83 /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8617EB765C0056DA83 /* KSVarArgs.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBF53E8F17EB7EA80056DA83 /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+GZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CBF53E8F17EB7EA80056DA83 /* NSData+KSCrashGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+KSCrashGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBF53E9117EB7EA80056DA83 /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8D17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E9217EB7EA80056DA83 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E9317EB7EA80056DA83 /* KSCrashInstallation+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2717EB765C0056DA83 /* KSCrashInstallation+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -583,7 +583,7 @@
 		EDF2BEAB1CCF15AD004BADF4 /* KSCrashInstallationVictory.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D2F17EB765C0056DA83 /* KSCrashInstallationVictory.m */; };
 		EDF2BEAC1CCF15AD004BADF4 /* KSCrashReportSinkStandard.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D4817EB765C0056DA83 /* KSCrashReportSinkStandard.m */; };
 		EDF2BEAD1CCF15AD004BADF4 /* KSCString.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D6217EB765C0056DA83 /* KSCString.m */; };
-		EDF2BEAE1CCF15AD004BADF4 /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+GZip.m */; };
+		EDF2BEAE1CCF15AD004BADF4 /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+KSCrashGZip.m */; };
 		EDF2BEB01CCF15AD004BADF4 /* KSObjC.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D7517EB765C0056DA83 /* KSObjC.c */; };
 		EDF2BEB11CCF15AD004BADF4 /* KSCrashReportFilterJSON.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D3E17EB765C0056DA83 /* KSCrashReportFilterJSON.m */; };
 		EDF2BEB21CCF15AD004BADF4 /* KSCrashInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D2617EB765C0056DA83 /* KSCrashInstallation.m */; };
@@ -634,7 +634,7 @@
 		EDF2BEE91CCF15AD004BADF4 /* KSCrashReportFields.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D3217EB765C0056DA83 /* KSCrashReportFields.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEEA1CCF15AD004BADF4 /* KSCrashMonitor_NSException.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D5417EB765C0056DA83 /* KSCrashMonitor_NSException.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEEB1CCF15AD004BADF4 /* AlignOf.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC43F0F1C5AF2B10083A11B /* AlignOf.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EDF2BEEC1CCF15AD004BADF4 /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+GZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDF2BEEC1CCF15AD004BADF4 /* NSData+KSCrashGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+KSCrashGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EDF2BEED1CCF15AD004BADF4 /* KSCrashMonitor_User.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D5A17EB765C0056DA83 /* KSCrashMonitor_User.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEEE1CCF15AD004BADF4 /* StringRef.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC43F0B1C5AF2B10083A11B /* StringRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEEF1CCF15AD004BADF4 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -769,7 +769,7 @@
 				632D8DF51EDFFA6700A9A62E /* KSCrashReportFilterStringify.h in Copy Headers */,
 				632D8DF61EDFFA6700A9A62E /* Container+DeepSearch.h in Copy Headers */,
 				632D8DF71EDFFA6700A9A62E /* KSVarArgs.h in Copy Headers */,
-				632D8DF81EDFFA6700A9A62E /* NSData+GZip.h in Copy Headers */,
+				632D8DF81EDFFA6700A9A62E /* NSData+KSCrashGZip.h in Copy Headers */,
 				632D8DF91EDFFA6700A9A62E /* KSCrashReportSinkConsole.h in Copy Headers */,
 				632D8DFA1EDFFA6700A9A62E /* KSCrashReportSinkEMail.h in Copy Headers */,
 				632D8DFB1EDFFA6700A9A62E /* KSCrashReportSinkQuincyHockey.h in Copy Headers */,
@@ -1026,8 +1026,8 @@
 		CBF53D8617EB765C0056DA83 /* KSVarArgs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSVarArgs.h; path = ../../Source/KSCrash/Reporting/Filters/Tools/KSVarArgs.h; sourceTree = "<group>"; };
 		CBF53D8717EB765C0056DA83 /* KSCrashMonitor_Zombie.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashMonitor_Zombie.h; path = ../../Source/KSCrash/Recording/Monitors/KSCrashMonitor_Zombie.h; sourceTree = "<group>"; };
 		CBF53D8817EB765C0056DA83 /* KSCrashMonitor_Zombie.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = KSCrashMonitor_Zombie.c; path = ../../Source/KSCrash/Recording/Monitors/KSCrashMonitor_Zombie.c; sourceTree = "<group>"; };
-		CBF53D8917EB765C0056DA83 /* NSData+GZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+GZip.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.h"; sourceTree = "<group>"; };
-		CBF53D8A17EB765C0056DA83 /* NSData+GZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+GZip.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.m"; sourceTree = "<group>"; };
+		CBF53D8917EB765C0056DA83 /* NSData+KSCrashGZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+KSCrashGZip.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.h"; sourceTree = "<group>"; };
+		CBF53D8A17EB765C0056DA83 /* NSData+KSCrashGZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+KSCrashGZip.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+KSCrashGZip.m"; sourceTree = "<group>"; };
 		CBF53D8D17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+KSCrashSimpleConstructor.h"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.h"; sourceTree = "<group>"; };
 		CBF53D8E17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+KSCrashSimpleConstructor.m"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.m"; sourceTree = "<group>"; };
 		CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableData+AppendUTF8.h"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.h"; sourceTree = "<group>"; };
@@ -1482,8 +1482,8 @@
 				CBF53D1317EB765C0056DA83 /* Container+DeepSearch.h */,
 				CBF53D1417EB765C0056DA83 /* Container+DeepSearch.m */,
 				CBF53D8617EB765C0056DA83 /* KSVarArgs.h */,
-				CBF53D8917EB765C0056DA83 /* NSData+GZip.h */,
-				CBF53D8A17EB765C0056DA83 /* NSData+GZip.m */,
+				CBF53D8917EB765C0056DA83 /* NSData+KSCrashGZip.h */,
+				CBF53D8A17EB765C0056DA83 /* NSData+KSCrashGZip.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -1516,7 +1516,7 @@
 				03DE7CC71C84DFCD00F789BA /* KSCrashInstallation+Private.h in Headers */,
 				03DE7DAA1C879A0200F789BA /* KSCrashAblyForkFramework.h in Headers */,
 				CB5657EF1E1D8A71005A8302 /* KSStackCursor_SelfThread.h in Headers */,
-				03DE7CBB1C84DFBC00F789BA /* NSData+GZip.h in Headers */,
+				03DE7CBB1C84DFBC00F789BA /* NSData+KSCrashGZip.h in Headers */,
 				03DE7CD21C84DFD000F789BA /* KSCrash.h in Headers */,
 				03DE7C421C84DF8100F789BA /* KSCrashC.h in Headers */,
 				CB5633CD1DD5392A0023CEB6 /* KSCrashMonitorContext.h in Headers */,
@@ -1683,7 +1683,7 @@
 				CBF53E7117EB7EA80056DA83 /* KSObjC.h in Headers */,
 				CBF53E6C17EB7EA80056DA83 /* KSJSONCodec.h in Headers */,
 				CBF53E5F17EB7EA80056DA83 /* KSCrashMonitor.h in Headers */,
-				CBF53E8F17EB7EA80056DA83 /* NSData+GZip.h in Headers */,
+				CBF53E8F17EB7EA80056DA83 /* NSData+KSCrashGZip.h in Headers */,
 				CBF53E5D17EB7EA80056DA83 /* KSCrashMonitor_System.h in Headers */,
 				CBF53E7417EB7EA80056DA83 /* KSSignalInfo.h in Headers */,
 				CB25A5BA1DF2182A00EC2B02 /* KSCPU.h in Headers */,
@@ -1766,7 +1766,7 @@
 				EDF2BEE91CCF15AD004BADF4 /* KSCrashReportFields.h in Headers */,
 				EDF2BEEA1CCF15AD004BADF4 /* KSCrashMonitor_NSException.h in Headers */,
 				EDF2BEEB1CCF15AD004BADF4 /* AlignOf.h in Headers */,
-				EDF2BEEC1CCF15AD004BADF4 /* NSData+GZip.h in Headers */,
+				EDF2BEEC1CCF15AD004BADF4 /* NSData+KSCrashGZip.h in Headers */,
 				EDF2BEED1CCF15AD004BADF4 /* KSCrashMonitor_User.h in Headers */,
 				EDF2BEEE1CCF15AD004BADF4 /* StringRef.h in Headers */,
 				EDF2BEEF1CCF15AD004BADF4 /* NSMutableData+AppendUTF8.h in Headers */,
@@ -2021,7 +2021,7 @@
 				03DE7CA71C84DFB100F789BA /* KSCrashReportSinkStandard.m in Sources */,
 				CBA8A0C61E2561210019B5B9 /* KSCrashCachedData.c in Sources */,
 				03DE7CBE1C84DFC100F789BA /* KSCString.m in Sources */,
-				03DE7CBC1C84DFBC00F789BA /* NSData+GZip.m in Sources */,
+				03DE7CBC1C84DFBC00F789BA /* NSData+KSCrashGZip.m in Sources */,
 				03DE7C8A1C84DFAB00F789BA /* KSObjC.c in Sources */,
 				03DE7CB51C84DFB700F789BA /* KSCrashReportFilterJSON.m in Sources */,
 				03DE7CC91C84DFCD00F789BA /* KSCrashInstallation.m in Sources */,
@@ -2101,7 +2101,7 @@
 				CBF53DA317EB765C0056DA83 /* KSCrashC.c in Sources */,
 				CBF53E1117EB765C0056DA83 /* KSJSONCodec.c in Sources */,
 				CBB61CC11E0035E4000C24A6 /* KSID.c in Sources */,
-				CBF53E4117EB765C0056DA83 /* NSData+GZip.m in Sources */,
+				CBF53E4117EB765C0056DA83 /* NSData+KSCrashGZip.m in Sources */,
 				CBA8A0C51E2561210019B5B9 /* KSCrashCachedData.c in Sources */,
 				CBF53E2017EB765C0056DA83 /* KSMemory.c in Sources */,
 				CBF53E0817EB765C0056DA83 /* KSFileUtils.c in Sources */,
@@ -2233,7 +2233,7 @@
 				EDF2BEAC1CCF15AD004BADF4 /* KSCrashReportSinkStandard.m in Sources */,
 				CBA8A0C71E2561210019B5B9 /* KSCrashCachedData.c in Sources */,
 				EDF2BEAD1CCF15AD004BADF4 /* KSCString.m in Sources */,
-				EDF2BEAE1CCF15AD004BADF4 /* NSData+GZip.m in Sources */,
+				EDF2BEAE1CCF15AD004BADF4 /* NSData+KSCrashGZip.m in Sources */,
 				EDF2BEB01CCF15AD004BADF4 /* KSObjC.c in Sources */,
 				EDF2BEB11CCF15AD004BADF4 /* KSCrashReportFilterJSON.m in Sources */,
 				EDF2BEB21CCF15AD004BADF4 /* KSCrashInstallation.m in Sources */,

--- a/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
+++ b/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
@@ -221,7 +221,7 @@
 		632D8E001EDFFA6700A9A62E /* KSHTTPRequestSender.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D6717EB765C0056DA83 /* KSHTTPRequestSender.h */; };
 		632D8E011EDFFA6700A9A62E /* KSReachabilityKSCrash.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D7817EB765C0056DA83 /* KSReachabilityKSCrash.h */; };
 		632D8E021EDFFA6700A9A62E /* NSMutableData+AppendUTF8.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */; };
-		632D8E031EDFFA6700A9A62E /* NSString+URLEncode.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC01CBC197D005EAF61 /* NSString+URLEncode.h */; };
+		632D8E031EDFFA6700A9A62E /* NSString+KSCrashURLEncode.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC01CBC197D005EAF61 /* NSString+KSCrashURLEncode.h */; };
 		632D8E041EDFFA6700A9A62E /* KSCrashInstallation.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2517EB765C0056DA83 /* KSCrashInstallation.h */; };
 		632D8E051EDFFA6700A9A62E /* KSCrashInstallation+Alert.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CB8F1DC41CCADB2A0022CDF0 /* KSCrashInstallation+Alert.h */; };
 		632D8E061EDFFA6700A9A62E /* KSCrashInstallation+Private.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2717EB765C0056DA83 /* KSCrashInstallation+Private.h */; };
@@ -431,10 +431,10 @@
 		CBC43F3E1C5AF2B10083A11B /* SwiftStrings.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC43F1D1C5AF2B10083A11B /* SwiftStrings.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBEE5C181CB83F4C005EAF61 /* KSSystemCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C171CB83F4C005EAF61 /* KSSystemCapabilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBEE5C191CB83F4C005EAF61 /* KSSystemCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5C171CB83F4C005EAF61 /* KSSystemCapabilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBEE5DC21CBC197D005EAF61 /* NSString+URLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC01CBC197D005EAF61 /* NSString+URLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBEE5DC31CBC197D005EAF61 /* NSString+URLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC01CBC197D005EAF61 /* NSString+URLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBEE5DC41CBC197D005EAF61 /* NSString+URLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DC11CBC197D005EAF61 /* NSString+URLEncode.m */; };
-		CBEE5DC51CBC197D005EAF61 /* NSString+URLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DC11CBC197D005EAF61 /* NSString+URLEncode.m */; };
+		CBEE5DC21CBC197D005EAF61 /* NSString+KSCrashURLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC01CBC197D005EAF61 /* NSString+KSCrashURLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBEE5DC31CBC197D005EAF61 /* NSString+KSCrashURLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC01CBC197D005EAF61 /* NSString+KSCrashURLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBEE5DC41CBC197D005EAF61 /* NSString+KSCrashURLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DC11CBC197D005EAF61 /* NSString+KSCrashURLEncode.m */; };
+		CBEE5DC51CBC197D005EAF61 /* NSString+KSCrashURLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DC11CBC197D005EAF61 /* NSString+KSCrashURLEncode.m */; };
 		CBF53D9617EB765C0056DA83 /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1417EB765C0056DA83 /* Container+DeepSearch.m */; };
 		CBF53DA017EB765C0056DA83 /* KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1C17EB765C0056DA83 /* KSCrash.m */; };
 		CBF53DA317EB765C0056DA83 /* KSCrashC.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1E17EB765C0056DA83 /* KSCrashC.c */; };
@@ -571,7 +571,7 @@
 		EDF2BE9C1CCF15AD004BADF4 /* KSHTTPRequestSender.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D6817EB765C0056DA83 /* KSHTTPRequestSender.m */; };
 		EDF2BE9D1CCF15AD004BADF4 /* KSCrashMonitor.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D5B17EB765C0056DA83 /* KSCrashMonitor.c */; };
 		EDF2BE9F1CCF15AD004BADF4 /* KSJSONCodecObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D6C17EB765C0056DA83 /* KSJSONCodecObjC.m */; };
-		EDF2BEA01CCF15AD004BADF4 /* NSString+URLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DC11CBC197D005EAF61 /* NSString+URLEncode.m */; };
+		EDF2BEA01CCF15AD004BADF4 /* NSString+KSCrashURLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DC11CBC197D005EAF61 /* NSString+KSCrashURLEncode.m */; };
 		EDF2BEA11CCF15AD004BADF4 /* KSCrashReportSinkQuincyHockey.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D4617EB765C0056DA83 /* KSCrashReportSinkQuincyHockey.m */; };
 		EDF2BEA21CCF15AD004BADF4 /* KSCPU_arm64.c in Sources */ = {isa = PBXBuildFile; fileRef = CB02647E17F7CEC5003E0AED /* KSCPU_arm64.c */; };
 		EDF2BEA31CCF15AD004BADF4 /* KSCrashReportSinkVictory.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D4A17EB765C0056DA83 /* KSCrashReportSinkVictory.m */; };
@@ -615,7 +615,7 @@
 		EDF2BED21CCF15AD004BADF4 /* KSCrashReportSinkEMail.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D4317EB765C0056DA83 /* KSCrashReportSinkEMail.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EDF2BED31CCF15AD004BADF4 /* KSCrashReportFilterJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D3D17EB765C0056DA83 /* KSCrashReportFilterJSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EDF2BED41CCF15AD004BADF4 /* KSCrashReportFilterStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = CB94D3611CAC190900806679 /* KSCrashReportFilterStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EDF2BED51CCF15AD004BADF4 /* NSString+URLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC01CBC197D005EAF61 /* NSString+URLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EDF2BED51CCF15AD004BADF4 /* NSString+KSCrashURLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC01CBC197D005EAF61 /* NSString+KSCrashURLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BED61CCF15AD004BADF4 /* KSCrashReportFilterGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D3B17EB765C0056DA83 /* KSCrashReportFilterGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EDF2BED71CCF15AD004BADF4 /* KSCrashReportFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D3317EB765C0056DA83 /* KSCrashReportFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EDF2BED81CCF15AD004BADF4 /* KSCrashReportFilterAppleFmt.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D3717EB765C0056DA83 /* KSCrashReportFilterAppleFmt.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -780,7 +780,7 @@
 				632D8E001EDFFA6700A9A62E /* KSHTTPRequestSender.h in Copy Headers */,
 				632D8E011EDFFA6700A9A62E /* KSReachabilityKSCrash.h in Copy Headers */,
 				632D8E021EDFFA6700A9A62E /* NSMutableData+AppendUTF8.h in Copy Headers */,
-				632D8E031EDFFA6700A9A62E /* NSString+URLEncode.h in Copy Headers */,
+				632D8E031EDFFA6700A9A62E /* NSString+KSCrashURLEncode.h in Copy Headers */,
 				632D8E041EDFFA6700A9A62E /* KSCrashInstallation.h in Copy Headers */,
 				632D8E051EDFFA6700A9A62E /* KSCrashInstallation+Alert.h in Copy Headers */,
 				632D8E061EDFFA6700A9A62E /* KSCrashInstallation+Private.h in Copy Headers */,
@@ -927,8 +927,8 @@
 		CBC43F1C1C5AF2B10083A11B /* Punycode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Punycode.h; sourceTree = "<group>"; };
 		CBC43F1D1C5AF2B10083A11B /* SwiftStrings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwiftStrings.h; sourceTree = "<group>"; };
 		CBEE5C171CB83F4C005EAF61 /* KSSystemCapabilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSSystemCapabilities.h; path = ../../Source/KSCrash/Recording/KSSystemCapabilities.h; sourceTree = "<group>"; };
-		CBEE5DC01CBC197D005EAF61 /* NSString+URLEncode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+URLEncode.h"; path = "../../Source/KSCrash/Reporting/Tools/NSString+URLEncode.h"; sourceTree = "<group>"; };
-		CBEE5DC11CBC197D005EAF61 /* NSString+URLEncode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+URLEncode.m"; path = "../../Source/KSCrash/Reporting/Tools/NSString+URLEncode.m"; sourceTree = "<group>"; };
+		CBEE5DC01CBC197D005EAF61 /* NSString+KSCrashURLEncode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+KSCrashURLEncode.h"; path = "../../Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.h"; sourceTree = "<group>"; };
+		CBEE5DC11CBC197D005EAF61 /* NSString+KSCrashURLEncode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+KSCrashURLEncode.m"; path = "../../Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.m"; sourceTree = "<group>"; };
 		CBF53D1317EB765C0056DA83 /* Container+DeepSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Container+DeepSearch.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+DeepSearch.h"; sourceTree = "<group>"; };
 		CBF53D1417EB765C0056DA83 /* Container+DeepSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+DeepSearch.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+DeepSearch.m"; sourceTree = "<group>"; };
 		CBF53D1B17EB765C0056DA83 /* KSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrash.h; path = ../../Source/KSCrash/Recording/KSCrash.h; sourceTree = "<group>"; };
@@ -1447,8 +1447,8 @@
 				CBF53D7917EB765C0056DA83 /* KSReachabilityKSCrash.m */,
 				CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */,
 				CBF53D9017EB765C0056DA83 /* NSMutableData+AppendUTF8.m */,
-				CBEE5DC01CBC197D005EAF61 /* NSString+URLEncode.h */,
-				CBEE5DC11CBC197D005EAF61 /* NSString+URLEncode.m */,
+				CBEE5DC01CBC197D005EAF61 /* NSString+KSCrashURLEncode.h */,
+				CBEE5DC11CBC197D005EAF61 /* NSString+KSCrashURLEncode.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -1538,7 +1538,7 @@
 				CB94D3641CAC190900806679 /* KSCrashReportFilterStringify.h in Headers */,
 				CB48F6D61DCD0D490099D264 /* KSDemangle_Swift.h in Headers */,
 				CB48F6D01DCD0D490099D264 /* KSDemangle_CPP.h in Headers */,
-				CBEE5DC31CBC197D005EAF61 /* NSString+URLEncode.h in Headers */,
+				CBEE5DC31CBC197D005EAF61 /* NSString+KSCrashURLEncode.h in Headers */,
 				03DE7CB21C84DFB700F789BA /* KSCrashReportFilterGZip.h in Headers */,
 				03DE7CAA1C84DFB600F789BA /* KSCrashReportFilter.h in Headers */,
 				03DE7CAE1C84DFB600F789BA /* KSCrashReportFilterAppleFmt.h in Headers */,
@@ -1646,7 +1646,7 @@
 				CBF53E8417EB7EA80056DA83 /* KSCrashReportSinkVictory.h in Headers */,
 				CBF53E8617EB7EA80056DA83 /* KSCrashReportStore.h in Headers */,
 				CBF53E5A17EB7EA80056DA83 /* KSCrashReportWriter.h in Headers */,
-				CBEE5DC21CBC197D005EAF61 /* NSString+URLEncode.h in Headers */,
+				CBEE5DC21CBC197D005EAF61 /* NSString+KSCrashURLEncode.h in Headers */,
 				DCA19E2D18817AD100DCA792 /* KSCrashReportFilterAlert.h in Headers */,
 				CBEE5C181CB83F4C005EAF61 /* KSSystemCapabilities.h in Headers */,
 				DCA19E3018817BA200DCA792 /* KSCrashReportFilterSets.h in Headers */,
@@ -1741,7 +1741,7 @@
 				EDF2BED21CCF15AD004BADF4 /* KSCrashReportSinkEMail.h in Headers */,
 				EDF2BED31CCF15AD004BADF4 /* KSCrashReportFilterJSON.h in Headers */,
 				EDF2BED41CCF15AD004BADF4 /* KSCrashReportFilterStringify.h in Headers */,
-				EDF2BED51CCF15AD004BADF4 /* NSString+URLEncode.h in Headers */,
+				EDF2BED51CCF15AD004BADF4 /* NSString+KSCrashURLEncode.h in Headers */,
 				EDF2BED61CCF15AD004BADF4 /* KSCrashReportFilterGZip.h in Headers */,
 				EDF2BED71CCF15AD004BADF4 /* KSCrashReportFilter.h in Headers */,
 				CB48F6D71DCD0D490099D264 /* KSDemangle_Swift.h in Headers */,
@@ -2007,7 +2007,7 @@
 				CB69B8E61DC0F15C002713B1 /* KSCrashReportStore.c in Sources */,
 				03DE7C801C84DFAB00F789BA /* KSJSONCodecObjC.m in Sources */,
 				CB25A6131DF25EF100EC2B02 /* KSMachineContext.c in Sources */,
-				CBEE5DC51CBC197D005EAF61 /* NSString+URLEncode.m in Sources */,
+				CBEE5DC51CBC197D005EAF61 /* NSString+KSCrashURLEncode.m in Sources */,
 				03DE7CA51C84DFB100F789BA /* KSCrashReportSinkQuincyHockey.m in Sources */,
 				03DE7C861C84DFAB00F789BA /* KSCPU_arm64.c in Sources */,
 				03DE7CA91C84DFB100F789BA /* KSCrashReportSinkVictory.m in Sources */,
@@ -2093,7 +2093,7 @@
 				CBF53E3917EB765C0056DA83 /* KSCrashMonitor_System.m in Sources */,
 				CB69B8E51DC0F15C002713B1 /* KSCrashReportStore.c in Sources */,
 				CBF53E1517EB765C0056DA83 /* KSJSONCodecObjC.m in Sources */,
-				CBEE5DC41CBC197D005EAF61 /* NSString+URLEncode.m in Sources */,
+				CBEE5DC41CBC197D005EAF61 /* NSString+KSCrashURLEncode.m in Sources */,
 				CBF53DBD17EB765C0056DA83 /* KSCrashReport.c in Sources */,
 				CBF53E0617EB765C0056DA83 /* KSCString.m in Sources */,
 				CBF53E2417EB765C0056DA83 /* KSObjC.c in Sources */,
@@ -2219,7 +2219,7 @@
 				CB69B8E71DC0F15C002713B1 /* KSCrashReportStore.c in Sources */,
 				EDF2BE9F1CCF15AD004BADF4 /* KSJSONCodecObjC.m in Sources */,
 				CB25A6141DF25EF100EC2B02 /* KSMachineContext.c in Sources */,
-				EDF2BEA01CCF15AD004BADF4 /* NSString+URLEncode.m in Sources */,
+				EDF2BEA01CCF15AD004BADF4 /* NSString+KSCrashURLEncode.m in Sources */,
 				EDF2BEA11CCF15AD004BADF4 /* KSCrashReportSinkQuincyHockey.m in Sources */,
 				EDF2BEA21CCF15AD004BADF4 /* KSCPU_arm64.c in Sources */,
 				EDF2BEA31CCF15AD004BADF4 /* KSCrashReportSinkVictory.m in Sources */,

--- a/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
+++ b/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
@@ -79,8 +79,8 @@
 		03DE7C951C84DFAB00F789BA /* KSSysCtl.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8217EB765C0056DA83 /* KSSysCtl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		03DE7C961C84DFAB00F789BA /* KSCrashMonitor_Zombie.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8717EB765C0056DA83 /* KSCrashMonitor_Zombie.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		03DE7C971C84DFAB00F789BA /* KSCrashMonitor_Zombie.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8817EB765C0056DA83 /* KSCrashMonitor_Zombie.c */; };
-		03DE7C9A1C84DFAB00F789BA /* NSError+SimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8D17EB765C0056DA83 /* NSError+SimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		03DE7C9B1C84DFAB00F789BA /* NSError+SimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8E17EB765C0056DA83 /* NSError+SimpleConstructor.m */; };
+		03DE7C9A1C84DFAB00F789BA /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8D17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		03DE7C9B1C84DFAB00F789BA /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8E17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m */; };
 		03DE7CA01C84DFB100F789BA /* KSCrashReportSinkConsole.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D4117EB765C0056DA83 /* KSCrashReportSinkConsole.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03DE7CA11C84DFB100F789BA /* KSCrashReportSinkConsole.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D4217EB765C0056DA83 /* KSCrashReportSinkConsole.m */; };
 		03DE7CA21C84DFB100F789BA /* KSCrashReportSinkEMail.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D4317EB765C0056DA83 /* KSCrashReportSinkEMail.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -199,7 +199,7 @@
 		632D8DEA1EDFFA6700A9A62E /* KSSymbolicator.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CB5657DA1E1CB8CE005A8302 /* KSSymbolicator.h */; };
 		632D8DEB1EDFFA6700A9A62E /* KSSysCtl.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8217EB765C0056DA83 /* KSSysCtl.h */; };
 		632D8DEC1EDFFA6700A9A62E /* KSThread.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CB25A5D61DF22F4000EC2B02 /* KSThread.h */; };
-		632D8DED1EDFFA6700A9A62E /* NSError+SimpleConstructor.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8D17EB765C0056DA83 /* NSError+SimpleConstructor.h */; };
+		632D8DED1EDFFA6700A9A62E /* NSError+KSCrashSimpleConstructor.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8D17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.h */; };
 		632D8DEE1EDFFA6700A9A62E /* KSCrashReportFilter.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D3317EB765C0056DA83 /* KSCrashReportFilter.h */; };
 		632D8DEF1EDFFA6700A9A62E /* KSCrashReportFilterAlert.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = DCA19E2B18817AD100DCA792 /* KSCrashReportFilterAlert.h */; };
 		632D8DF01EDFFA6700A9A62E /* KSCrashReportFilterAppleFmt.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D3717EB765C0056DA83 /* KSCrashReportFilterAppleFmt.h */; };
@@ -261,7 +261,7 @@
 		CB0264C317FA5B13003E0AED /* KSString_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB02649E17FA5B13003E0AED /* KSString_Tests.m */; };
 		CB0264C417FA5B13003E0AED /* KSSysCtl_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB02649F17FA5B13003E0AED /* KSSysCtl_Tests.m */; };
 		CB0264C717FA5B13003E0AED /* NSData+Gzip_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0264A217FA5B13003E0AED /* NSData+Gzip_Tests.m */; };
-		CB0264C917FA5B13003E0AED /* NSError+SimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0264A417FA5B13003E0AED /* NSError+SimpleConstructor_Tests.m */; };
+		CB0264C917FA5B13003E0AED /* NSError+KSCrashSimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0264A417FA5B13003E0AED /* NSError+KSCrashSimpleConstructor_Tests.m */; };
 		CB0264CA17FA5B13003E0AED /* NSMutableData+AppendUTF8_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0264A517FA5B13003E0AED /* NSMutableData+AppendUTF8_Tests.m */; };
 		CB0264CB17FA5B13003E0AED /* RFC3339UTFString_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0264A617FA5B13003E0AED /* RFC3339UTFString_Tests.m */; };
 		CB0264CC17FA5B13003E0AED /* XCTestCase+KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0264A817FA5B13003E0AED /* XCTestCase+KSCrash.m */; };
@@ -482,7 +482,7 @@
 		CBF53E3917EB765C0056DA83 /* KSCrashMonitor_System.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8417EB765C0056DA83 /* KSCrashMonitor_System.m */; };
 		CBF53E3E17EB765C0056DA83 /* KSCrashMonitor_Zombie.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8817EB765C0056DA83 /* KSCrashMonitor_Zombie.c */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		CBF53E4117EB765C0056DA83 /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+GZip.m */; };
-		CBF53E4717EB765C0056DA83 /* NSError+SimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8E17EB765C0056DA83 /* NSError+SimpleConstructor.m */; };
+		CBF53E4717EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8E17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m */; };
 		CBF53E4A17EB765C0056DA83 /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D9017EB765C0056DA83 /* NSMutableData+AppendUTF8.m */; };
 		CBF53E5617EB7EA80056DA83 /* KSCrashC.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1F17EB765C0056DA83 /* KSCrashC.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBF53E5817EB7EA80056DA83 /* KSCrashReport.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D3117EB765C0056DA83 /* KSCrashReport.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -528,7 +528,7 @@
 		CBF53E8C17EB7EA80056DA83 /* KSReachabilityKSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D7817EB765C0056DA83 /* KSReachabilityKSCrash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E8E17EB7EA80056DA83 /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8617EB765C0056DA83 /* KSVarArgs.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E8F17EB7EA80056DA83 /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+GZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CBF53E9117EB7EA80056DA83 /* NSError+SimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8D17EB765C0056DA83 /* NSError+SimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBF53E9117EB7EA80056DA83 /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8D17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E9217EB7EA80056DA83 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E9317EB7EA80056DA83 /* KSCrashInstallation+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2717EB765C0056DA83 /* KSCrashInstallation+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBF53E9417EB7EA80056DA83 /* KSCrashInstallation.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2517EB765C0056DA83 /* KSCrashInstallation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -546,7 +546,7 @@
 		EDF2BE7E1CCF15AD004BADF4 /* KSCrashReportSinkEMail.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D4417EB765C0056DA83 /* KSCrashReportSinkEMail.m */; };
 		EDF2BE7F1CCF15AD004BADF4 /* Demangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CBC43F151C5AF2B10083A11B /* Demangle.cpp */; };
 		EDF2BE801CCF15AD004BADF4 /* KSCrashInstallationEmail.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D2917EB765C0056DA83 /* KSCrashInstallationEmail.m */; };
-		EDF2BE811CCF15AD004BADF4 /* NSError+SimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8E17EB765C0056DA83 /* NSError+SimpleConstructor.m */; };
+		EDF2BE811CCF15AD004BADF4 /* NSError+KSCrashSimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8E17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m */; };
 		EDF2BE831CCF15AD004BADF4 /* KSCPU_x86_64.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D7117EB765C0056DA83 /* KSCPU_x86_64.c */; };
 		EDF2BE841CCF15AD004BADF4 /* KSReachabilityKSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D7917EB765C0056DA83 /* KSReachabilityKSCrash.m */; };
 		EDF2BE851CCF15AD004BADF4 /* KSCrashInstallationConsole.m in Sources */ = {isa = PBXBuildFile; fileRef = CB94D35C1CAC11B000806679 /* KSCrashInstallationConsole.m */; };
@@ -651,7 +651,7 @@
 		EDF2BEFB1CCF15AD004BADF4 /* KSDynamicLinker.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7A6C9117FB96FF00997792 /* KSDynamicLinker.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEFC1CCF15AD004BADF4 /* KSCrashMonitor_Deadlock.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D5017EB765C0056DA83 /* KSCrashMonitor_Deadlock.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEFD1CCF15AD004BADF4 /* Punycode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC43F1C1C5AF2B10083A11B /* Punycode.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EDF2BEFE1CCF15AD004BADF4 /* NSError+SimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8D17EB765C0056DA83 /* NSError+SimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EDF2BEFE1CCF15AD004BADF4 /* NSError+KSCrashSimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8D17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEFF1CCF15AD004BADF4 /* KSCString.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D6117EB765C0056DA83 /* KSCString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BF001CCF15AD004BADF4 /* Casting.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC43F101C5AF2B10083A11B /* Casting.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BF011CCF15AD004BADF4 /* Compiler.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC43F111C5AF2B10083A11B /* Compiler.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -758,7 +758,7 @@
 				632D8DEA1EDFFA6700A9A62E /* KSSymbolicator.h in Copy Headers */,
 				632D8DEB1EDFFA6700A9A62E /* KSSysCtl.h in Copy Headers */,
 				632D8DEC1EDFFA6700A9A62E /* KSThread.h in Copy Headers */,
-				632D8DED1EDFFA6700A9A62E /* NSError+SimpleConstructor.h in Copy Headers */,
+				632D8DED1EDFFA6700A9A62E /* NSError+KSCrashSimpleConstructor.h in Copy Headers */,
 				632D8DEE1EDFFA6700A9A62E /* KSCrashReportFilter.h in Copy Headers */,
 				632D8DEF1EDFFA6700A9A62E /* KSCrashReportFilterAlert.h in Copy Headers */,
 				632D8DF01EDFFA6700A9A62E /* KSCrashReportFilterAppleFmt.h in Copy Headers */,
@@ -832,7 +832,7 @@
 		CB02649F17FA5B13003E0AED /* KSSysCtl_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSSysCtl_Tests.m; path = "../../Source/KSCrash-Tests/KSSysCtl_Tests.m"; sourceTree = "<group>"; };
 		CB0264A117FA5B13003E0AED /* KSCrashMonitor_Zombie_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashMonitor_Zombie_Tests.m; path = "../../Source/KSCrash-Tests/KSCrashMonitor_Zombie_Tests.m"; sourceTree = "<group>"; };
 		CB0264A217FA5B13003E0AED /* NSData+Gzip_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+Gzip_Tests.m"; path = "../../Source/KSCrash-Tests/NSData+Gzip_Tests.m"; sourceTree = "<group>"; };
-		CB0264A417FA5B13003E0AED /* NSError+SimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+SimpleConstructor_Tests.m"; path = "../../Source/KSCrash-Tests/NSError+SimpleConstructor_Tests.m"; sourceTree = "<group>"; };
+		CB0264A417FA5B13003E0AED /* NSError+KSCrashSimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+KSCrashSimpleConstructor_Tests.m"; path = "../../Source/KSCrash-Tests/NSError+KSCrashSimpleConstructor_Tests.m"; sourceTree = "<group>"; };
 		CB0264A517FA5B13003E0AED /* NSMutableData+AppendUTF8_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+AppendUTF8_Tests.m"; path = "../../Source/KSCrash-Tests/NSMutableData+AppendUTF8_Tests.m"; sourceTree = "<group>"; };
 		CB0264A617FA5B13003E0AED /* RFC3339UTFString_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RFC3339UTFString_Tests.m; path = "../../Source/KSCrash-Tests/RFC3339UTFString_Tests.m"; sourceTree = "<group>"; };
 		CB0264A717FA5B13003E0AED /* XCTestCase+KSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+KSCrash.h"; path = "../../Source/KSCrash-Tests/XCTestCase+KSCrash.h"; sourceTree = "<group>"; };
@@ -1028,8 +1028,8 @@
 		CBF53D8817EB765C0056DA83 /* KSCrashMonitor_Zombie.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = KSCrashMonitor_Zombie.c; path = ../../Source/KSCrash/Recording/Monitors/KSCrashMonitor_Zombie.c; sourceTree = "<group>"; };
 		CBF53D8917EB765C0056DA83 /* NSData+GZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+GZip.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.h"; sourceTree = "<group>"; };
 		CBF53D8A17EB765C0056DA83 /* NSData+GZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+GZip.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.m"; sourceTree = "<group>"; };
-		CBF53D8D17EB765C0056DA83 /* NSError+SimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+SimpleConstructor.h"; path = "../../Source/KSCrash/Recording/Tools/NSError+SimpleConstructor.h"; sourceTree = "<group>"; };
-		CBF53D8E17EB765C0056DA83 /* NSError+SimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+SimpleConstructor.m"; path = "../../Source/KSCrash/Recording/Tools/NSError+SimpleConstructor.m"; sourceTree = "<group>"; };
+		CBF53D8D17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+KSCrashSimpleConstructor.h"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.h"; sourceTree = "<group>"; };
+		CBF53D8E17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+KSCrashSimpleConstructor.m"; path = "../../Source/KSCrash/Recording/Tools/NSError+KSCrashSimpleConstructor.m"; sourceTree = "<group>"; };
 		CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableData+AppendUTF8.h"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.h"; sourceTree = "<group>"; };
 		CBF53D9017EB765C0056DA83 /* NSMutableData+AppendUTF8.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableData+AppendUTF8.m"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.m"; sourceTree = "<group>"; };
 		DCA19E2B18817AD100DCA792 /* KSCrashReportFilterAlert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashReportFilterAlert.h; path = ../../Source/KSCrash/Reporting/Filters/KSCrashReportFilterAlert.h; sourceTree = "<group>"; };
@@ -1185,7 +1185,7 @@
 				CB02649F17FA5B13003E0AED /* KSSysCtl_Tests.m */,
 				CB25A5DD1DF231E600EC2B02 /* KSThread_Tests.m */,
 				CB0264A217FA5B13003E0AED /* NSData+Gzip_Tests.m */,
-				CB0264A417FA5B13003E0AED /* NSError+SimpleConstructor_Tests.m */,
+				CB0264A417FA5B13003E0AED /* NSError+KSCrashSimpleConstructor_Tests.m */,
 				CB0264A517FA5B13003E0AED /* NSMutableData+AppendUTF8_Tests.m */,
 				CB0264A617FA5B13003E0AED /* RFC3339UTFString_Tests.m */,
 				CB6D131517EB743A00BC2C04 /* Supporting Files */,
@@ -1428,8 +1428,8 @@
 				CBF53D8217EB765C0056DA83 /* KSSysCtl.h */,
 				CB25A5D51DF22F4000EC2B02 /* KSThread.c */,
 				CB25A5D61DF22F4000EC2B02 /* KSThread.h */,
-				CBF53D8D17EB765C0056DA83 /* NSError+SimpleConstructor.h */,
-				CBF53D8E17EB765C0056DA83 /* NSError+SimpleConstructor.m */,
+				CBF53D8D17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.h */,
+				CBF53D8E17EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -1584,7 +1584,7 @@
 				03DE7C571C84DF8600F789BA /* KSCrashMonitor_Deadlock.h in Headers */,
 				03DE7C711C84DFA400F789BA /* Punycode.h in Headers */,
 				CB25A6071DF23D7300EC2B02 /* KSCPU_Apple.h in Headers */,
-				03DE7C9A1C84DFAB00F789BA /* NSError+SimpleConstructor.h in Headers */,
+				03DE7C9A1C84DFAB00F789BA /* NSError+KSCrashSimpleConstructor.h in Headers */,
 				03DE7CBD1C84DFC100F789BA /* KSCString.h in Headers */,
 				03DE7C671C84DF9F00F789BA /* Casting.h in Headers */,
 				03DE7C681C84DF9F00F789BA /* Compiler.h in Headers */,
@@ -1660,7 +1660,7 @@
 				CBF53E6E17EB7EA80056DA83 /* KSLogger.h in Headers */,
 				CBF53E7617EB7EA80056DA83 /* KSSysCtl.h in Headers */,
 				CBF53E6117EB7EA80056DA83 /* KSCrashMonitor_Deadlock.h in Headers */,
-				CBF53E9117EB7EA80056DA83 /* NSError+SimpleConstructor.h in Headers */,
+				CBF53E9117EB7EA80056DA83 /* NSError+KSCrashSimpleConstructor.h in Headers */,
 				CB69B8C81DC03FFF002713B1 /* KSDate.h in Headers */,
 				CBF53E9217EB7EA80056DA83 /* NSMutableData+AppendUTF8.h in Headers */,
 				CB0C19C21DD0F2EE005B2F80 /* KSCrashReportFixer.h in Headers */,
@@ -1788,7 +1788,7 @@
 				EDF2BEFC1CCF15AD004BADF4 /* KSCrashMonitor_Deadlock.h in Headers */,
 				CB0C19C41DD0F2EE005B2F80 /* KSCrashReportFixer.h in Headers */,
 				EDF2BEFD1CCF15AD004BADF4 /* Punycode.h in Headers */,
-				EDF2BEFE1CCF15AD004BADF4 /* NSError+SimpleConstructor.h in Headers */,
+				EDF2BEFE1CCF15AD004BADF4 /* NSError+KSCrashSimpleConstructor.h in Headers */,
 				EDF2BEFF1CCF15AD004BADF4 /* KSCString.h in Headers */,
 				CB25A6081DF23D7300EC2B02 /* KSCPU_Apple.h in Headers */,
 				EDF2BF001CCF15AD004BADF4 /* Casting.h in Headers */,
@@ -1976,7 +1976,7 @@
 				CB0C19C01DD0F2EE005B2F80 /* KSCrashReportFixer.c in Sources */,
 				03DE7CCB1C84DFCD00F789BA /* KSCrashInstallationEmail.m in Sources */,
 				CB5657DC1E1CB8CE005A8302 /* KSSymbolicator.c in Sources */,
-				03DE7C9B1C84DFAB00F789BA /* NSError+SimpleConstructor.m in Sources */,
+				03DE7C9B1C84DFAB00F789BA /* NSError+KSCrashSimpleConstructor.m in Sources */,
 				03DE7C881C84DFAB00F789BA /* KSCPU_x86_64.c in Sources */,
 				03DE7CC41C84DFC100F789BA /* KSReachabilityKSCrash.m in Sources */,
 				CB94D3601CAC11B000806679 /* KSCrashInstallationConsole.m in Sources */,
@@ -2109,7 +2109,7 @@
 				CBF53DD117EB765C0056DA83 /* KSCrashReportFilterJSON.m in Sources */,
 				CBC43F3A1C5AF2B10083A11B /* Punycode.cpp in Sources */,
 				CBF53E4A17EB765C0056DA83 /* NSMutableData+AppendUTF8.m in Sources */,
-				CBF53E4717EB765C0056DA83 /* NSError+SimpleConstructor.m in Sources */,
+				CBF53E4717EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m in Sources */,
 				CBF53DCB17EB765C0056DA83 /* KSCrashReportFilterBasic.m in Sources */,
 				CBF53E3E17EB765C0056DA83 /* KSCrashMonitor_Zombie.c in Sources */,
 				CBF53D9617EB765C0056DA83 /* Container+DeepSearch.m in Sources */,
@@ -2160,7 +2160,7 @@
 				CB0264B317FA5B13003E0AED /* KSCrashReportFilterJSON_Tests.m in Sources */,
 				CB0264B117FA5B13003E0AED /* KSCrashReportFilterAlert_Tests.m in Sources */,
 				CB25A5CC1DF2292F00EC2B02 /* KSCPU_Tests.m in Sources */,
-				CB0264C917FA5B13003E0AED /* NSError+SimpleConstructor_Tests.m in Sources */,
+				CB0264C917FA5B13003E0AED /* NSError+KSCrashSimpleConstructor_Tests.m in Sources */,
 				CB0264C717FA5B13003E0AED /* NSData+Gzip_Tests.m in Sources */,
 				CB0264AF17FA5B13003E0AED /* KSCrashReportConverter_Tests.m in Sources */,
 				CB0264A917FA5B13003E0AED /* Container+DeepSearch_Tests.m in Sources */,
@@ -2188,7 +2188,7 @@
 				CB0C19C11DD0F2EE005B2F80 /* KSCrashReportFixer.c in Sources */,
 				EDF2BE801CCF15AD004BADF4 /* KSCrashInstallationEmail.m in Sources */,
 				CB5657DD1E1CB8CE005A8302 /* KSSymbolicator.c in Sources */,
-				EDF2BE811CCF15AD004BADF4 /* NSError+SimpleConstructor.m in Sources */,
+				EDF2BE811CCF15AD004BADF4 /* NSError+KSCrashSimpleConstructor.m in Sources */,
 				EDF2BE831CCF15AD004BADF4 /* KSCPU_x86_64.c in Sources */,
 				EDF2BE841CCF15AD004BADF4 /* KSReachabilityKSCrash.m in Sources */,
 				EDF2BE851CCF15AD004BADF4 /* KSCrashInstallationConsole.m in Sources */,

--- a/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
+++ b/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
@@ -104,8 +104,8 @@
 		03DE7CB51C84DFB700F789BA /* KSCrashReportFilterJSON.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D3E17EB765C0056DA83 /* KSCrashReportFilterJSON.m */; };
 		03DE7CB61C84DFB700F789BA /* KSCrashReportFilterSets.h in Headers */ = {isa = PBXBuildFile; fileRef = DCA19E2E18817BA200DCA792 /* KSCrashReportFilterSets.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03DE7CB71C84DFB700F789BA /* KSCrashReportFilterSets.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D4017EB765C0056DA83 /* KSCrashReportFilterSets.m */; };
-		03DE7CB81C84DFBC00F789BA /* Container+DeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1317EB765C0056DA83 /* Container+DeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		03DE7CB91C84DFBC00F789BA /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1417EB765C0056DA83 /* Container+DeepSearch.m */; };
+		03DE7CB81C84DFBC00F789BA /* Container+KSCrashDeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1317EB765C0056DA83 /* Container+KSCrashDeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		03DE7CB91C84DFBC00F789BA /* Container+KSCrashDeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1417EB765C0056DA83 /* Container+KSCrashDeepSearch.m */; };
 		03DE7CBA1C84DFBC00F789BA /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8617EB765C0056DA83 /* KSVarArgs.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		03DE7CBB1C84DFBC00F789BA /* NSData+KSCrashGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+KSCrashGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03DE7CBC1C84DFBC00F789BA /* NSData+KSCrashGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+KSCrashGZip.m */; };
@@ -208,7 +208,7 @@
 		632D8DF31EDFFA6700A9A62E /* KSCrashReportFilterJSON.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D3D17EB765C0056DA83 /* KSCrashReportFilterJSON.h */; };
 		632D8DF41EDFFA6700A9A62E /* KSCrashReportFilterSets.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = DCA19E2E18817BA200DCA792 /* KSCrashReportFilterSets.h */; };
 		632D8DF51EDFFA6700A9A62E /* KSCrashReportFilterStringify.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CB94D3611CAC190900806679 /* KSCrashReportFilterStringify.h */; };
-		632D8DF61EDFFA6700A9A62E /* Container+DeepSearch.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1317EB765C0056DA83 /* Container+DeepSearch.h */; };
+		632D8DF61EDFFA6700A9A62E /* Container+KSCrashDeepSearch.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1317EB765C0056DA83 /* Container+KSCrashDeepSearch.h */; };
 		632D8DF71EDFFA6700A9A62E /* KSVarArgs.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8617EB765C0056DA83 /* KSVarArgs.h */; };
 		632D8DF81EDFFA6700A9A62E /* NSData+KSCrashGZip.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+KSCrashGZip.h */; };
 		632D8DF91EDFFA6700A9A62E /* KSCrashReportSinkConsole.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D4117EB765C0056DA83 /* KSCrashReportSinkConsole.h */; };
@@ -233,7 +233,7 @@
 		632D8E0C1EDFFA6700A9A62E /* KSCrash.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1B17EB765C0056DA83 /* KSCrash.h */; };
 		CB02648017F7CEC5003E0AED /* KSCPU_arm64.c in Sources */ = {isa = PBXBuildFile; fileRef = CB02647E17F7CEC5003E0AED /* KSCPU_arm64.c */; };
 		CB02648217F8D853003E0AED /* KSCrashMonitor_CPPException.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D4F17EB765C0056DA83 /* KSCrashMonitor_CPPException.cpp */; };
-		CB0264A917FA5B13003E0AED /* Container+DeepSearch_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB02648317FA5B12003E0AED /* Container+DeepSearch_Tests.m */; };
+		CB0264A917FA5B13003E0AED /* Container+KSCrashDeepSearch_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB02648317FA5B12003E0AED /* Container+KSCrashDeepSearch_Tests.m */; };
 		CB0264AA17FA5B13003E0AED /* FileBasedTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = CB02648517FA5B12003E0AED /* FileBasedTestCase.m */; };
 		CB0264AB17FA5B13003E0AED /* KSCrashInstallationEmail_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB02648617FA5B12003E0AED /* KSCrashInstallationEmail_Tests.m */; };
 		CB0264AC17FA5B13003E0AED /* KSCrashInstallationQuincyHockey_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB02648717FA5B12003E0AED /* KSCrashInstallationQuincyHockey_Tests.m */; };
@@ -435,7 +435,7 @@
 		CBEE5DC31CBC197D005EAF61 /* NSString+KSCrashURLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = CBEE5DC01CBC197D005EAF61 /* NSString+KSCrashURLEncode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBEE5DC41CBC197D005EAF61 /* NSString+KSCrashURLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DC11CBC197D005EAF61 /* NSString+KSCrashURLEncode.m */; };
 		CBEE5DC51CBC197D005EAF61 /* NSString+KSCrashURLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = CBEE5DC11CBC197D005EAF61 /* NSString+KSCrashURLEncode.m */; };
-		CBF53D9617EB765C0056DA83 /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1417EB765C0056DA83 /* Container+DeepSearch.m */; };
+		CBF53D9617EB765C0056DA83 /* Container+KSCrashDeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1417EB765C0056DA83 /* Container+KSCrashDeepSearch.m */; };
 		CBF53DA017EB765C0056DA83 /* KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1C17EB765C0056DA83 /* KSCrash.m */; };
 		CBF53DA317EB765C0056DA83 /* KSCrashC.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1E17EB765C0056DA83 /* KSCrashC.c */; };
 		CBF53DAB17EB765C0056DA83 /* KSCrashDoctor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D2417EB765C0056DA83 /* KSCrashDoctor.m */; };
@@ -521,7 +521,7 @@
 		CBF53E8417EB7EA80056DA83 /* KSCrashReportSinkVictory.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D4917EB765C0056DA83 /* KSCrashReportSinkVictory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBF53E8517EB7EA80056DA83 /* KSCrashDoctor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2317EB765C0056DA83 /* KSCrashDoctor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E8617EB7EA80056DA83 /* KSCrashReportStore.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D4B17EB765C0056DA83 /* KSCrashReportStore.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBF53E8717EB7EA80056DA83 /* Container+DeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1317EB765C0056DA83 /* Container+DeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBF53E8717EB7EA80056DA83 /* Container+KSCrashDeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1317EB765C0056DA83 /* Container+KSCrashDeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E8917EB7EA80056DA83 /* KSCString.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D6117EB765C0056DA83 /* KSCString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E8A17EB7EA80056DA83 /* KSHTTPMultipartPostBody.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D6517EB765C0056DA83 /* KSHTTPMultipartPostBody.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E8B17EB7EA80056DA83 /* KSHTTPRequestSender.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D6717EB765C0056DA83 /* KSHTTPRequestSender.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -592,7 +592,7 @@
 		EDF2BEB51CCF15AD004BADF4 /* NSMutableData+KSCrashAppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D9017EB765C0056DA83 /* NSMutableData+KSCrashAppendUTF8.m */; };
 		EDF2BEB61CCF15AD004BADF4 /* KSCrashMonitorType.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D5F17EB765C0056DA83 /* KSCrashMonitorType.c */; };
 		EDF2BEB71CCF15AD004BADF4 /* KSCrashReportFilterAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D3617EB765C0056DA83 /* KSCrashReportFilterAlert.m */; };
-		EDF2BEB81CCF15AD004BADF4 /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1417EB765C0056DA83 /* Container+DeepSearch.m */; };
+		EDF2BEB81CCF15AD004BADF4 /* Container+KSCrashDeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1417EB765C0056DA83 /* Container+KSCrashDeepSearch.m */; };
 		EDF2BEB91CCF15AD004BADF4 /* KSHTTPMultipartPostBody.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D6617EB765C0056DA83 /* KSHTTPMultipartPostBody.m */; };
 		EDF2BEBA1CCF15AD004BADF4 /* KSCrashReportFilterBasic.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D3A17EB765C0056DA83 /* KSCrashReportFilterBasic.m */; };
 		EDF2BEBB1CCF15AD004BADF4 /* KSCrashReportFilterSets.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D4017EB765C0056DA83 /* KSCrashReportFilterSets.m */; };
@@ -670,7 +670,7 @@
 		EDF2BF131CCF15AD004BADF4 /* Fallthrough.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC43F181C5AF2B10083A11B /* Fallthrough.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BF141CCF15AD004BADF4 /* None.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC43F091C5AF2B10083A11B /* None.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BF151CCF15AD004BADF4 /* KSObjC.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D7617EB765C0056DA83 /* KSObjC.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EDF2BF171CCF15AD004BADF4 /* Container+DeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1317EB765C0056DA83 /* Container+DeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EDF2BF171CCF15AD004BADF4 /* Container+KSCrashDeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1317EB765C0056DA83 /* Container+KSCrashDeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BF181CCF15AD004BADF4 /* KSCrashMonitor_Signal.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D5817EB765C0056DA83 /* KSCrashMonitor_Signal.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BF191CCF15AD004BADF4 /* KSCrashMonitor_Zombie.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8717EB765C0056DA83 /* KSCrashMonitor_Zombie.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BF1A1CCF15AD004BADF4 /* KSCrashMonitor_MachException.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D5317EB765C0056DA83 /* KSCrashMonitor_MachException.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -767,7 +767,7 @@
 				632D8DF31EDFFA6700A9A62E /* KSCrashReportFilterJSON.h in Copy Headers */,
 				632D8DF41EDFFA6700A9A62E /* KSCrashReportFilterSets.h in Copy Headers */,
 				632D8DF51EDFFA6700A9A62E /* KSCrashReportFilterStringify.h in Copy Headers */,
-				632D8DF61EDFFA6700A9A62E /* Container+DeepSearch.h in Copy Headers */,
+				632D8DF61EDFFA6700A9A62E /* Container+KSCrashDeepSearch.h in Copy Headers */,
 				632D8DF71EDFFA6700A9A62E /* KSVarArgs.h in Copy Headers */,
 				632D8DF81EDFFA6700A9A62E /* NSData+KSCrashGZip.h in Copy Headers */,
 				632D8DF91EDFFA6700A9A62E /* KSCrashReportSinkConsole.h in Copy Headers */,
@@ -802,7 +802,7 @@
 		03DE7D0F1C84FB9E00F789BA /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; name = module.modulemap; path = ../../Source/Framework/module.modulemap; sourceTree = "<group>"; };
 		03DE7DA91C879A0200F789BA /* KSCrashAblyForkFramework.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashAblyForkFramework.h; path = ../../Source/Framework/KSCrashAblyForkFramework.h; sourceTree = "<group>"; };
 		CB02647E17F7CEC5003E0AED /* KSCPU_arm64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = KSCPU_arm64.c; path = ../../Source/KSCrash/Recording/Tools/KSCPU_arm64.c; sourceTree = "<group>"; };
-		CB02648317FA5B12003E0AED /* Container+DeepSearch_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+DeepSearch_Tests.m"; path = "../../Source/KSCrash-Tests/Container+DeepSearch_Tests.m"; sourceTree = "<group>"; };
+		CB02648317FA5B12003E0AED /* Container+KSCrashDeepSearch_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+KSCrashDeepSearch_Tests.m"; path = "../../Source/KSCrash-Tests/Container+KSCrashDeepSearch_Tests.m"; sourceTree = "<group>"; };
 		CB02648417FA5B12003E0AED /* FileBasedTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FileBasedTestCase.h; path = "../../Source/KSCrash-Tests/FileBasedTestCase.h"; sourceTree = "<group>"; };
 		CB02648517FA5B12003E0AED /* FileBasedTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FileBasedTestCase.m; path = "../../Source/KSCrash-Tests/FileBasedTestCase.m"; sourceTree = "<group>"; };
 		CB02648617FA5B12003E0AED /* KSCrashInstallationEmail_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashInstallationEmail_Tests.m; path = "../../Source/KSCrash-Tests/KSCrashInstallationEmail_Tests.m"; sourceTree = "<group>"; };
@@ -929,8 +929,8 @@
 		CBEE5C171CB83F4C005EAF61 /* KSSystemCapabilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSSystemCapabilities.h; path = ../../Source/KSCrash/Recording/KSSystemCapabilities.h; sourceTree = "<group>"; };
 		CBEE5DC01CBC197D005EAF61 /* NSString+KSCrashURLEncode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+KSCrashURLEncode.h"; path = "../../Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.h"; sourceTree = "<group>"; };
 		CBEE5DC11CBC197D005EAF61 /* NSString+KSCrashURLEncode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+KSCrashURLEncode.m"; path = "../../Source/KSCrash/Reporting/Tools/NSString+KSCrashURLEncode.m"; sourceTree = "<group>"; };
-		CBF53D1317EB765C0056DA83 /* Container+DeepSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Container+DeepSearch.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+DeepSearch.h"; sourceTree = "<group>"; };
-		CBF53D1417EB765C0056DA83 /* Container+DeepSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+DeepSearch.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+DeepSearch.m"; sourceTree = "<group>"; };
+		CBF53D1317EB765C0056DA83 /* Container+KSCrashDeepSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Container+KSCrashDeepSearch.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+KSCrashDeepSearch.h"; sourceTree = "<group>"; };
+		CBF53D1417EB765C0056DA83 /* Container+KSCrashDeepSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Container+KSCrashDeepSearch.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/Container+KSCrashDeepSearch.m"; sourceTree = "<group>"; };
 		CBF53D1B17EB765C0056DA83 /* KSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrash.h; path = ../../Source/KSCrash/Recording/KSCrash.h; sourceTree = "<group>"; };
 		CBF53D1C17EB765C0056DA83 /* KSCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrash.m; path = ../../Source/KSCrash/Recording/KSCrash.m; sourceTree = "<group>"; };
 		CBF53D1E17EB765C0056DA83 /* KSCrashC.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = KSCrashC.c; path = ../../Source/KSCrash/Recording/KSCrashC.c; sourceTree = "<group>"; };
@@ -1148,7 +1148,7 @@
 		CB6D131417EB743A00BC2C04 /* KSCrashTests */ = {
 			isa = PBXGroup;
 			children = (
-				CB02648317FA5B12003E0AED /* Container+DeepSearch_Tests.m */,
+				CB02648317FA5B12003E0AED /* Container+KSCrashDeepSearch_Tests.m */,
 				CB02648417FA5B12003E0AED /* FileBasedTestCase.h */,
 				CB02648517FA5B12003E0AED /* FileBasedTestCase.m */,
 				CB25A5CB1DF2292F00EC2B02 /* KSCPU_Tests.m */,
@@ -1479,8 +1479,8 @@
 		DCA19E311881BFEA00DCA792 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
-				CBF53D1317EB765C0056DA83 /* Container+DeepSearch.h */,
-				CBF53D1417EB765C0056DA83 /* Container+DeepSearch.m */,
+				CBF53D1317EB765C0056DA83 /* Container+KSCrashDeepSearch.h */,
+				CBF53D1417EB765C0056DA83 /* Container+KSCrashDeepSearch.m */,
 				CBF53D8617EB765C0056DA83 /* KSVarArgs.h */,
 				CBF53D8917EB765C0056DA83 /* NSData+KSCrashGZip.h */,
 				CBF53D8A17EB765C0056DA83 /* NSData+KSCrashGZip.m */,
@@ -1604,7 +1604,7 @@
 				CB25A5F31DF2396700EC2B02 /* KSDebug.h in Headers */,
 				03DE7C621C84DF9200F789BA /* None.h in Headers */,
 				03DE7C8B1C84DFAB00F789BA /* KSObjC.h in Headers */,
-				03DE7CB81C84DFBC00F789BA /* Container+DeepSearch.h in Headers */,
+				03DE7CB81C84DFBC00F789BA /* Container+KSCrashDeepSearch.h in Headers */,
 				03DE7C5F1C84DF8600F789BA /* KSCrashMonitor_Signal.h in Headers */,
 				03DE7C961C84DFAB00F789BA /* KSCrashMonitor_Zombie.h in Headers */,
 				03DE7C5A1C84DF8600F789BA /* KSCrashMonitor_MachException.h in Headers */,
@@ -1700,7 +1700,7 @@
 				CBF53E6217EB7EA80056DA83 /* KSCrashMonitor_MachException.h in Headers */,
 				CBC43F271C5AF2B10083A11B /* AlignOf.h in Headers */,
 				CBF53E9317EB7EA80056DA83 /* KSCrashInstallation+Private.h in Headers */,
-				CBF53E8717EB7EA80056DA83 /* Container+DeepSearch.h in Headers */,
+				CBF53E8717EB7EA80056DA83 /* Container+KSCrashDeepSearch.h in Headers */,
 				CBF53E8A17EB7EA80056DA83 /* KSHTTPMultipartPostBody.h in Headers */,
 				CBF53E6517EB7EA80056DA83 /* KSCrashMonitor_Signal.h in Headers */,
 				CBF53E5617EB7EA80056DA83 /* KSCrashC.h in Headers */,
@@ -1811,7 +1811,7 @@
 				CB25A5F41DF2396700EC2B02 /* KSDebug.h in Headers */,
 				EDF2BF141CCF15AD004BADF4 /* None.h in Headers */,
 				EDF2BF151CCF15AD004BADF4 /* KSObjC.h in Headers */,
-				EDF2BF171CCF15AD004BADF4 /* Container+DeepSearch.h in Headers */,
+				EDF2BF171CCF15AD004BADF4 /* Container+KSCrashDeepSearch.h in Headers */,
 				EDF2BF181CCF15AD004BADF4 /* KSCrashMonitor_Signal.h in Headers */,
 				EDF2BF191CCF15AD004BADF4 /* KSCrashMonitor_Zombie.h in Headers */,
 				EDF2BF1A1CCF15AD004BADF4 /* KSCrashMonitor_MachException.h in Headers */,
@@ -2033,7 +2033,7 @@
 				CB69B8C61DC03FFF002713B1 /* KSDate.c in Sources */,
 				03DE7CAD1C84DFB600F789BA /* KSCrashReportFilterAlert.m in Sources */,
 				CB5657EC1E1D8A71005A8302 /* KSStackCursor_SelfThread.c in Sources */,
-				03DE7CB91C84DFBC00F789BA /* Container+DeepSearch.m in Sources */,
+				03DE7CB91C84DFBC00F789BA /* Container+KSCrashDeepSearch.m in Sources */,
 				CB25A5B81DF2182A00EC2B02 /* KSCPU.c in Sources */,
 				03DE7CC01C84DFC100F789BA /* KSHTTPMultipartPostBody.m in Sources */,
 				03DE7CB11C84DFB600F789BA /* KSCrashReportFilterBasic.m in Sources */,
@@ -2112,7 +2112,7 @@
 				CBF53E4717EB765C0056DA83 /* NSError+KSCrashSimpleConstructor.m in Sources */,
 				CBF53DCB17EB765C0056DA83 /* KSCrashReportFilterBasic.m in Sources */,
 				CBF53E3E17EB765C0056DA83 /* KSCrashMonitor_Zombie.c in Sources */,
-				CBF53D9617EB765C0056DA83 /* Container+DeepSearch.m in Sources */,
+				CBF53D9617EB765C0056DA83 /* Container+KSCrashDeepSearch.m in Sources */,
 				CBF53DC517EB765C0056DA83 /* KSCrashReportFilterAlert.m in Sources */,
 				CBF53DA017EB765C0056DA83 /* KSCrash.m in Sources */,
 				CB5657EB1E1D8A71005A8302 /* KSStackCursor_SelfThread.c in Sources */,
@@ -2163,7 +2163,7 @@
 				CB0264C917FA5B13003E0AED /* NSError+KSCrashSimpleConstructor_Tests.m in Sources */,
 				CB0264C717FA5B13003E0AED /* NSData+Gzip_Tests.m in Sources */,
 				CB0264AF17FA5B13003E0AED /* KSCrashReportConverter_Tests.m in Sources */,
-				CB0264A917FA5B13003E0AED /* Container+DeepSearch_Tests.m in Sources */,
+				CB0264A917FA5B13003E0AED /* Container+KSCrashDeepSearch_Tests.m in Sources */,
 				CB0264BE17FA5B13003E0AED /* KSLogger_Tests.m in Sources */,
 				CB0264BB17FA5B13003E0AED /* KSCString_Tests.m in Sources */,
 				CB0264CC17FA5B13003E0AED /* XCTestCase+KSCrash.m in Sources */,
@@ -2245,7 +2245,7 @@
 				CB69B8C71DC03FFF002713B1 /* KSDate.c in Sources */,
 				EDF2BEB71CCF15AD004BADF4 /* KSCrashReportFilterAlert.m in Sources */,
 				CB5657ED1E1D8A71005A8302 /* KSStackCursor_SelfThread.c in Sources */,
-				EDF2BEB81CCF15AD004BADF4 /* Container+DeepSearch.m in Sources */,
+				EDF2BEB81CCF15AD004BADF4 /* Container+KSCrashDeepSearch.m in Sources */,
 				CB25A5B91DF2182A00EC2B02 /* KSCPU.c in Sources */,
 				EDF2BEB91CCF15AD004BADF4 /* KSHTTPMultipartPostBody.m in Sources */,
 				EDF2BEBA1CCF15AD004BADF4 /* KSCrashReportFilterBasic.m in Sources */,


### PR DESCRIPTION
We have a customer who is encountering compilation errors when using CocoaPods to build their solution where they include both the [ably-cocoa](https://github.com/ably/ably-cocoa) and [GZIP](https://cocoapods.org/pods/GZIP) pods.

What was happening for them was that the `NSData+GZip.h` header file from GZIP was being found by the build system when building KSCrash for Ably, before Ably's variant. This meant that the Ably GZip methods could not be found.

The errors from `CompileC`, as encountered prior to this fix by the customer, look like this:

```
/UserBuildPath/Pods/KSCrashAblyFork/Source/KSCrash/Reporting/Filters/KSCrashReportFilterGZip.m:63:42: error: no visible @interface for 'NSData' declares the selector 'gzippedWithCompressionLevel:error:'
        NSData* compressedData = [report gzippedWithCompressionLevel:self.compressionLevel
                                  ~~~~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/UserBuildPath/Pods/KSCrashAblyFork/Source/KSCrash/Reporting/Filters/KSCrashReportFilterGZip.m:96:44: error: no visible @interface for 'NSData' declares the selector 'gunzippedWithError:'
        NSData* decompressedData = [report gunzippedWithError:&error];
                                    ~~~~~~ ^~~~~~~~~~~~~~~~~~
2 errors generated.
```

The work undertaken here involved fixing the reported issue with a category name prefix (https://github.com/ably-forks/KSCrash/commit/d4484d605033ea86bb15d49a83984b7457caef88) as well as adding the same category name prefix to other categories defined against `NS` classes.